### PR TITLE
fix: remove optional type indicators

### DIFF
--- a/packages/ui/src/use-clipboard/index.tsx
+++ b/packages/ui/src/use-clipboard/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
 interface Clipboard {
-  value?: string;
-  onCopy?: () => void;
-  hasCopied?: boolean;
+  value: string;
+  onCopy: () => void;
+  hasCopied: boolean;
 }
 
 /**


### PR DESCRIPTION
All 3 properties are returned from hook, so no need for them to be defined as optional.

Prevents `onCopy && onCopy();` unnecessary type safety checks