### PR TITLE
refactor: use react-query for network status

### DIFF
--- a/src/common/api/wrapped-fetch.ts
+++ b/src/common/api/wrapped-fetch.ts
@@ -11,3 +11,21 @@ export function fetcher(input: RequestInfo, init: RequestInit = {}) {
     headers: { ...initHeaders, ...hiroHeaders },
   });
 }
+
+export async function fetchWithTimeout(
+  input: RequestInfo,
+  init: RequestInit & { timeout?: number } = {}
+) {
+  const { timeout = 8000, ...options } = init;
+
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+
+  const response = await fetcher(input, {
+    ...options,
+    signal: controller.signal,
+  });
+  clearTimeout(id);
+
+  return response;
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,10 +1,10 @@
 import React from 'react';
+import BigNumber from 'bignumber.js';
 import { wordlists } from 'bip39';
-import { BufferReader, deserializePostCondition, PostCondition } from '@stacks/transactions';
+
 import { KEBAB_REGEX, Network } from '@common/constants';
 import { StacksNetwork } from '@stacks/network';
-import { fetcher } from '@common/api/wrapped-fetch';
-import BigNumber from 'bignumber.js';
+import { BufferReader, deserializePostCondition, PostCondition } from '@stacks/transactions';
 
 function kebabCase(str: string) {
   return str.replace(KEBAB_REGEX, match => '-' + match.toLowerCase());
@@ -258,24 +258,6 @@ export function getUrlPort(url: string) {
 
 export async function delay(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-export async function fetchWithTimeout(
-  input: RequestInfo,
-  init: RequestInit & { timeout?: number } = {}
-) {
-  const { timeout = 8000, ...options } = init;
-
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-
-  const response = await fetcher(input, {
-    ...options,
-    signal: controller.signal,
-  });
-  clearTimeout(id);
-
-  return response;
 }
 
 export function with0x(value: string): string {

--- a/src/features/network-drawer/components/network-status-indicator.tsx
+++ b/src/features/network-drawer/components/network-status-indicator.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { FiCloudOff as IconCloudOff } from 'react-icons/fi';
+
+import { CheckmarkIcon } from '@components/icons/checkmark-icon';
+
+interface NetworkStatusIndicatorProps {
+  isActive: boolean;
+  isOnline: boolean;
+}
+
+export const NetworkStatusIndicator = ({ isActive, isOnline }: NetworkStatusIndicatorProps) => {
+  return !isOnline ? <IconCloudOff /> : isActive ? <CheckmarkIcon /> : null;
+};

--- a/src/features/network-drawer/network-list-item.tsx
+++ b/src/features/network-drawer/network-list-item.tsx
@@ -1,40 +1,21 @@
-import {
-  useNetworkOnlineStatusState,
-  useUpdateCurrentNetworkKey,
-} from '@store/network/networks.hooks';
-import React, { useCallback, useEffect, useState } from 'react';
-import { FiCloudOff as IconCloudOff } from 'react-icons/fi';
-import { CheckmarkIcon } from '@components/icons/checkmark-icon';
-import { Box, BoxProps, color, Flex, Spinner, Stack } from '@stacks/ui';
+import React, { useCallback } from 'react';
+
+import { Caption, Title } from '@components/typography';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { useWallet } from '@common/hooks/use-wallet';
-import { Caption, Title } from '@components/typography';
 import { getUrlHostname } from '@common/utils';
-
-interface OnlineIndicatorProps {
-  isOnline: boolean;
-  isActive: boolean;
-  setIsOnline: (value: boolean) => void;
-  network: {
-    url: string;
-  };
-}
-
-const OnlineIndicator = ({ isOnline, setIsOnline, network, isActive }: OnlineIndicatorProps) => {
-  const networkStatus = useNetworkOnlineStatusState(network.url);
-  useEffect(() => {
-    if (isOnline !== networkStatus.isOnline) setIsOnline(networkStatus.isOnline);
-  }, [isOnline, networkStatus.isOnline, setIsOnline]);
-  return !networkStatus?.isOnline ? <IconCloudOff /> : isActive ? <CheckmarkIcon /> : null;
-};
+import { Box, BoxProps, color, Flex, Stack } from '@stacks/ui';
+import { useUpdateCurrentNetworkKey } from '@store/network/networks.hooks';
+import { NetworkStatusIndicator } from './components/network-status-indicator';
+import { useNetworkStatus } from 'query/network/network.hooks';
 
 export const NetworkListItem: React.FC<{ item: string } & BoxProps> = ({ item, ...props }) => {
   const { setShowNetworks } = useDrawers();
   const { networks, currentNetworkKey } = useWallet();
   const setCurrentNetworkKey = useUpdateCurrentNetworkKey();
   const network = networks[item];
-  const [isOnline, setIsOnline] = useState(false);
   const isActive = item === currentNetworkKey;
+  const isOnline = useNetworkStatus(network.url);
 
   const handleItemClick = useCallback(() => {
     setCurrentNetworkKey(item);
@@ -72,21 +53,7 @@ export const NetworkListItem: React.FC<{ item: string } & BoxProps> = ({ item, .
           </Title>
           <Caption>{getUrlHostname(network.url)}</Caption>
         </Stack>
-        <React.Suspense
-          key={item}
-          fallback={
-            <Flex alignItems="center" justifyContent="center">
-              <Spinner size="sm" />
-            </Flex>
-          }
-        >
-          <OnlineIndicator
-            isActive={item === currentNetworkKey}
-            isOnline={isOnline}
-            setIsOnline={setIsOnline}
-            network={network}
-          />
-        </React.Suspense>
+        <NetworkStatusIndicator isActive={item === currentNetworkKey} isOnline={isOnline} />
       </Flex>
     </Box>
   );

--- a/src/query/network/network.hooks.ts
+++ b/src/query/network/network.hooks.ts
@@ -1,0 +1,6 @@
+import { useGetNetworkStatus } from './network.query';
+
+export function useNetworkStatus(url: string): boolean {
+  const result = useGetNetworkStatus(url);
+  return result.isSuccess;
+}

--- a/src/query/network/network.query.ts
+++ b/src/query/network/network.query.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query';
+
+import { fetchWithTimeout } from '@common/api/wrapped-fetch';
+
+const STALE_TIME = 15 * 60 * 1000; // 15 min
+
+const networkStatusQueryOptions = {
+  keepPreviousData: true,
+  cacheTime: STALE_TIME,
+  refetchOnMount: false,
+  refetchInterval: false,
+  refetchOnReconnect: false,
+} as const;
+
+function getNetworkStatusFetcher() {
+  return (url: string) => () => fetchWithTimeout(url, { timeout: 4500 });
+}
+
+export function useGetNetworkStatus(url: string) {
+  return useQuery({
+    queryKey: ['network-status', url],
+    queryFn: getNetworkStatusFetcher()(url),
+    ...networkStatusQueryOptions,
+  });
+}

--- a/src/store/network/networks.hooks.ts
+++ b/src/store/network/networks.hooks.ts
@@ -3,7 +3,6 @@ import {
   currentNetworkKeyState,
   currentNetworkState,
   currentStacksNetworkState,
-  networkOnlineStatusState,
   networksState,
 } from './networks';
 
@@ -29,8 +28,4 @@ export function useCurrentNetworkKey() {
 
 export function useUpdateCurrentNetworkKey() {
   return useUpdateAtom(currentNetworkKeyState);
-}
-
-export function useNetworkOnlineStatusState(networkUrl: string) {
-  return useAtomValue(networkOnlineStatusState(networkUrl));
 }

--- a/src/store/network/networks.ts
+++ b/src/store/network/networks.ts
@@ -1,12 +1,12 @@
-import { atomWithStorage } from 'jotai/utils';
 import { atom } from 'jotai';
-import { ChainID } from '@stacks/transactions';
+import { atomWithStorage } from 'jotai/utils';
+
+import { defaultNetworks, Networks } from '@common/constants';
+import { findMatchingNetworkKey } from '@common/utils';
 import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
-import { transactionRequestNetwork } from '@store/transactions/requests';
-import { fetchWithTimeout, findMatchingNetworkKey } from '@common/utils';
-import { defaultNetworks, Networks, QueryRefreshRates } from '@common/constants';
-import { atomFamilyWithQuery } from '@store/query';
+import { ChainID } from '@stacks/transactions';
 import { apiClientState } from '@store/common/api-clients';
+import { transactionRequestNetwork } from '@store/transactions/requests';
 import { makeLocalDataKey } from '@common/store-utils';
 
 // Our root networks list, users can add to this list and it will persist to localstorage
@@ -18,7 +18,6 @@ export const networksState = atomWithStorage<Networks>(
 // the current key selected
 // if there is a pending transaction request, it will default to the network passed (if included)
 // else it will default to the persisted key or default (mainnet)
-
 const localCurrentNetworkKeyState = atomWithStorage(makeLocalDataKey('networkKey'), 'mainnet');
 export const currentNetworkKeyState = atom<string, string>(
   get => {
@@ -61,21 +60,6 @@ export const latestBlockHeightState = atom(async get => {
 
 // external data, `v2/info` endpoint of the selected network
 export const networkInfoState = atom(get => get(apiClientState).infoApi.getCoreApiInfo());
-
-export const networkOnlineStatusState = atomFamilyWithQuery<string, { isOnline: boolean }>(
-  'NETWORK_ONLINE',
-  async (_get, networkUrl) => {
-    let isOnline = false;
-    try {
-      const res = await fetchWithTimeout(networkUrl, { timeout: 4500 });
-      isOnline = res?.status === 200;
-    } catch (e) {}
-    return {
-      isOnline,
-    };
-  },
-  { refetchInterval: QueryRefreshRates.VERY_SLOW }
-);
 
 networksState.debugLabel = 'networksState';
 localCurrentNetworkKeyState.debugLabel = 'localCurrentNetworkKeyState';


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1337539694).<!-- Sticky Header Marker -->

- Closes #1803 
- Branches off #1816
- Uses react-query and removes `atomFamilyWithQuery`
- Moves `fetchWithTimeout` to be located with `fetcher` (which it uses)
- Moves `NetworkStatusIndicator` to be its own component
- Showing offline unless `isOnline` instead of showing a loading spinner

cc/ @kyranjamie @beguene 
