### PR TITLE
ci: run gh actions on release pr updates

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -45,4 +48,4 @@ jobs:
           title: "[RELEASE] Version extension"
           commit: 'Version release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1337745956).<!-- Sticky Header Marker -->

Closes https://github.com/blockstack/stacks-wallet-web/issues/1817

Uses the personal access token to checkout the full history of the repo under the correct user. This should help fix the problem where force-push updates to a release branch don't run GH action.

cc/ @kyranjamie @fbwoolf
