### PR TITLE
feat/add-bns-tab-test-app

### DIFF
--- a/test-app/src/components/bns.tsx
+++ b/test-app/src/components/bns.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Box, Button, Text } from '@stacks/ui';
+
+export const Bns = () => {
+  return (
+    <Box py={6}>
+      <Text as="h2" textStyle="display.small">
+        BNS
+      </Text>
+      <Text textStyle="body.large" display="block" my={'loose'}>
+        Use the testnet version of btc.us to QA BNS names
+      </Text>
+      <Button onClick={() => window.open('https://btc-website.tintashlabs.com/')}>
+        Open testnet btc.us
+      </Button>
+    </Box>
+  );
+};

--- a/test-app/src/components/home.tsx
+++ b/test-app/src/components/home.tsx
@@ -6,8 +6,9 @@ import { Tab } from './tab';
 import { Status } from './status';
 import { Counter } from './counter';
 import { Debugger } from './debugger';
+import { Bns } from './bns';
 
-type Tabs = 'status' | 'counter' | 'debug';
+type Tabs = 'status' | 'counter' | 'debug' | 'bns';
 
 const Container: React.FC<BoxProps> = ({ children, ...props }) => {
   return (
@@ -33,12 +34,16 @@ const Page: React.FC<{ tab: Tabs; setTab: (value: Tabs) => void }> = ({ tab, set
           <Tab active={tab === 'counter'}>
             <Text onClick={() => setTab('counter')}>Counter smart contract</Text>
           </Tab>
+          <Tab active={tab === 'bns'}>
+            <Text onClick={() => setTab('bns')}>BNS</Text>
+          </Tab>
         </Flex>
       </Container>
       <Container>
         {tab === 'status' && <Status />}
         {tab === 'counter' && <Counter />}
         {tab === 'debug' && <Debugger />}
+        {tab === 'bns' && <Bns />}
       </Container>
     </>
   );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1358540146).<!-- Sticky Header Marker -->

Adds small helper tab with link to test app