### PR TITLE
fix: add release rules to commit analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,17 @@
       "main"
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "releaseRules": [
+            {
+              "type": "refactor",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
       "@semantic-release/release-notes-generator",
       [
         "@semantic-release/npm",


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1795887368).<!-- Sticky Header Marker -->

This PR adds `releaseRules` to our commit-analyzer so that using `refactor:` in the commit message will trigger a build for QA to test.

cc/ @kyranjamie @beguene @He1DAr 
