### PR TITLE
Use the anchor mode from the input transaction

### DIFF
--- a/src/app/common/transactions/generate-unsigned-txs.ts
+++ b/src/app/common/transactions/generate-unsigned-txs.ts
@@ -41,6 +41,7 @@ function generateUnsignedContractCallTx(args: GenerateUnsignedContractCallTxArgs
     postConditionMode,
     postConditions,
     network,
+    anchorMode,
   } = txData;
 
   const fnArgs = functionArgs.map(arg => deserializeCV(hexToBuff(arg)));
@@ -50,7 +51,7 @@ function generateUnsignedContractCallTx(args: GenerateUnsignedContractCallTxArgs
     contractAddress,
     functionName,
     publicKey,
-    anchorMode: AnchorMode.Any,
+    anchorMode: anchorMode ?? AnchorMode.Any,
     functionArgs: fnArgs,
     nonce: initNonce(nonce),
     fee: new BN(fee, 10),
@@ -66,14 +67,14 @@ type GenerateUnsignedContractDeployTxArgs = GenerateUnsignedTxArgs<ContractDeplo
 
 function generateUnsignedContractDeployTx(args: GenerateUnsignedContractDeployTxArgs) {
   const { txData, publicKey, nonce, fee } = args;
-  const { contractName, codeBody, network, postConditions, postConditionMode } = txData;
+  const { contractName, codeBody, network, postConditions, postConditionMode, anchorMode } = txData;
   const options = {
     contractName,
     codeBody,
     nonce: initNonce(nonce),
     fee: new BN(fee, 10),
     publicKey,
-    anchorMode: AnchorMode.Any,
+    anchorMode: anchorMode ?? AnchorMode.Any,
     postConditionMode: postConditionMode,
     postConditions: getPostConditions(postConditions),
     network,
@@ -85,12 +86,12 @@ type GenerateUnsignedStxTransferTxArgs = GenerateUnsignedTxArgs<STXTransferPaylo
 
 function generateUnsignedStxTransferTx(args: GenerateUnsignedStxTransferTxArgs) {
   const { txData, publicKey, nonce, fee } = args;
-  const { recipient, memo, amount, network } = txData;
+  const { recipient, memo, amount, network, anchorMode } = txData;
   const options = {
     recipient,
     memo,
     publicKey,
-    anchorMode: AnchorMode.Any,
+    anchorMode: anchorMode ?? AnchorMode.Any,
     amount: new BN(amount),
     nonce: initNonce(nonce),
     fee: new BN(fee, 10),


### PR DESCRIPTION
Fixes #2469 

When we request a transaction signature, we now keep the same `anchorMode` as the input transaction

I pretty much figured this out with a debugger so you'll definitely have a better idea of what this flow is, but the gist of it is:

- we get an input transaction, passed as `options.txData` in the input to `generateUnsignedTransaction`
- that calls `generateUnsignedContractCallTx` for contract calls, the function I've updated
- that then builds its own `options` object of type `UnsignedContractCallOptions`, and that becomes the transaction to sign
- in those `options` being built, the `anchorMode` was hardcoded to `AnchorMode.any`. This PR updates that to use `txData.anchorMode` if defined, else `AnchorMode.any` by default. This means that if the dapp sets the anchor mode on a transaction, then it will be used for the transaction broadcast by the wallet

You can test this using https://microblocks-test.vercel.app (repro I created for #2469). Notice that the transaction fetched after signing now has the correct anchor mode:

<img width="450" alt="Screenshot 2022-06-01 at 17 08 48" src="https://user-images.githubusercontent.com/1711350/171451062-409cb578-6348-4dcb-87b8-d66de7fcdae6.png">

cc/ @kyranjamie @fbwoolf @beguene @He1DAr