### PR TITLE
ci: prevent updating pr body on forks

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -17,6 +17,7 @@ jobs:
 
   update-pull-request-body:
     name: Add links to built extensions
+    if: github.repository == 'hirosystems/stacks-wallet-web'
     runs-on: ubuntu-latest
     needs:
       - pre_run


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2528092425).<!-- Sticky Header Marker -->

Noticed dependabot fails for this one ci job