### PR TITLE
fix: send form white screen

### DIFF
--- a/src/app/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/app/pages/send-tokens/components/send-form-inner.tsx
@@ -113,7 +113,8 @@ export function SendFormInner(props: SendFormInnerProps) {
     setFieldError('amount', undefined);
   }, [assets.length, setValues, values, nonce, setFieldError]);
 
-  const hasValues = values.amount && values.recipient !== '' && values.fee && values.nonce;
+  const hasValues =
+    values.amount && values.recipient !== '' && values.fee && values.nonce !== undefined;
 
   const symbol = selectedAsset?.type === 'stx' ? 'STX' : selectedAsset?.meta?.symbol;
 

--- a/src/app/pages/send-tokens/send-tokens.tsx
+++ b/src/app/pages/send-tokens/send-tokens.tsx
@@ -88,7 +88,7 @@ function SendTokensFormBase() {
     [broadcastTransactionFn, handleConfirmDrawerOnClose, navigate, setFeeEstimations]
   );
 
-  if (assets.length < 1 || !nonce) return null;
+  if (assets.length < 1) return null;
 
   const initialValues = {
     amount: '',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2538623044).<!-- Sticky Header Marker -->

This fixes the white screen seen on the send form with a new account.

cc/ @kyranjamie @fbwoolf @beguene
