### PR TITLE
fix: refactor JSX namespace to React.JSX

### DIFF
--- a/src/app/common/hooks/use-route-header.ts
+++ b/src/app/common/hooks/use-route-header.ts
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
 
-export function useRouteHeader(header: JSX.Element, isParentRoute?: boolean) {
+export function useRouteHeader(header: React.JSX.Element, isParentRoute?: boolean) {
   const location = useLocation();
   const [_, setRouteHeader] = useRouteHeaderState();
   useEffect(() => {

--- a/src/app/common/theme-provider.tsx
+++ b/src/app/common/theme-provider.tsx
@@ -44,7 +44,7 @@ function setUserSelectedTheme(theme: UserSelectedTheme) {
 }
 
 interface ThemeSwitcherProviderProps {
-  children: JSX.Element | JSX.Element[];
+  children: React.JSX.Element | React.JSX.Element[];
 }
 export function ThemeSwitcherProvider({ children }: ThemeSwitcherProviderProps) {
   const userSelectedTheme = useUserSelectedTheme();

--- a/src/app/components/brc20-tokens-loader.tsx
+++ b/src/app/components/brc20-tokens-loader.tsx
@@ -4,7 +4,7 @@ import {
 } from '@app/query/bitcoin/ordinals/brc20/brc20-tokens.query';
 
 interface Brc20TokensLoaderProps {
-  children(brc20Tokens: Brc20Token[]): JSX.Element;
+  children(brc20Tokens: Brc20Token[]): React.JSX.Element;
 }
 export function Brc20TokensLoader({ children }: Brc20TokensLoaderProps) {
   const { data: allBrc20TokensResponse } = useBrc20TokensQuery();

--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
@@ -17,8 +17,8 @@ import { Caption, Text } from '@app/components/typography';
 interface CryptoCurrencyAssetItemLayoutProps extends StackProps {
   balance: Money;
   caption: string;
-  icon: JSX.Element;
-  copyIcon?: JSX.Element;
+  icon: React.JSX.Element;
+  copyIcon?: React.JSX.Element;
   isPressable?: boolean;
   title: string;
   usdBalance?: string;
@@ -26,8 +26,8 @@ interface CryptoCurrencyAssetItemLayoutProps extends StackProps {
   canCopy?: boolean;
   isHovered?: boolean;
   currency?: CryptoCurrencies;
-  additionalBalanceInfo?: JSX.Element;
-  additionalUsdBalanceInfo?: JSX.Element;
+  additionalBalanceInfo?: React.JSX.Element;
+  additionalUsdBalanceInfo?: React.JSX.Element;
 }
 export const CryptoCurrencyAssetItemLayout = forwardRefWithAs(
   (props: CryptoCurrencyAssetItemLayoutProps, ref) => {

--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.tsx
@@ -13,13 +13,13 @@ import { CryptoCurrencyAssetItemLayout } from './crypto-currency-asset-item.layo
 
 interface CryptoCurrencyAssetItemProps extends StackProps {
   assetBalance: AllCryptoCurrencyAssetBalances;
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   usdBalance?: string;
   address?: string;
   isPressable?: boolean;
   canCopy?: boolean;
-  additionalBalanceInfo?: JSX.Element;
-  additionalUsdBalanceInfo?: JSX.Element;
+  additionalBalanceInfo?: React.JSX.Element;
+  additionalUsdBalanceInfo?: React.JSX.Element;
 }
 export const CryptoCurrencyAssetItem = forwardRefWithAs(
   (props: CryptoCurrencyAssetItemProps, ref) => {

--- a/src/app/components/drawer/base-drawer.tsx
+++ b/src/app/components/drawer/base-drawer.tsx
@@ -32,7 +32,7 @@ function useDrawer(isShowing: boolean, onClose: () => void, pause?: boolean) {
 interface BaseDrawerProps extends Omit<FlexProps, 'title'> {
   children?: ReactNode;
   enableGoBack?: boolean;
-  icon?: JSX.Element;
+  icon?: React.JSX.Element;
   isShowing: boolean;
   isWaitingOnPerformedAction?: boolean;
   onClose?(): void;

--- a/src/app/components/drawer/components/drawer-header.tsx
+++ b/src/app/components/drawer/components/drawer-header.tsx
@@ -9,7 +9,7 @@ import { HeaderActionButton } from './header-action-button';
 
 interface DrawerHeaderProps {
   enableGoBack?: boolean;
-  icon?: JSX.Element;
+  icon?: React.JSX.Element;
   isWaitingOnPerformedAction?: boolean;
   onClose?(): void;
   onGoBack(): void;

--- a/src/app/components/drawer/components/header-action-button.tsx
+++ b/src/app/components/drawer/components/header-action-button.tsx
@@ -10,7 +10,7 @@ interface IconBaseProps extends SVGAttributes<SVGElement> {
   color?: string;
   title?: string;
 }
-type IconType = (props: IconBaseProps) => JSX.Element;
+type IconType = (props: IconBaseProps) => React.JSX.Element;
 
 interface HeaderActionButtonProps {
   icon?: IconType;

--- a/src/app/components/drawer/controlled-drawer.tsx
+++ b/src/app/components/drawer/controlled-drawer.tsx
@@ -5,7 +5,7 @@ import { BaseDrawer } from './base-drawer';
 interface ControlledDrawerProps {
   children?: ReactNode;
   enableGoBack?: boolean;
-  icon?: JSX.Element;
+  icon?: React.JSX.Element;
   isShowing: boolean;
   onClose(): void;
   pauseOnClickOutside?: boolean;

--- a/src/app/components/event-card.tsx
+++ b/src/app/components/event-card.tsx
@@ -18,7 +18,7 @@ interface EventCardProps {
   ticker: string;
   title: string;
 }
-export function EventCard(props: EventCardProps): JSX.Element {
+export function EventCard(props: EventCardProps): React.JSX.Element {
   const { actions, amount, icon, isLast, left, message, right, ticker, title } = props;
 
   return (

--- a/src/app/components/fees-row/components/fees-row.layout.tsx
+++ b/src/app/components/fees-row/components/fees-row.layout.tsx
@@ -7,10 +7,10 @@ import { Caption } from '@app/components/typography';
 import { WarningLabel } from '@app/components/warning-label';
 
 interface FeesRowLayoutProps extends StackProps {
-  feeField: JSX.Element;
+  feeField: React.JSX.Element;
   fieldWarning?: string;
   isSponsored: boolean;
-  selectInput: JSX.Element;
+  selectInput: React.JSX.Element;
 }
 export function FeesRowLayout(props: FeesRowLayoutProps) {
   const { feeField, fieldWarning, isSponsored, selectInput, ...rest } = props;

--- a/src/app/components/fees-row/fees-row.tsx
+++ b/src/app/components/fees-row/fees-row.tsx
@@ -23,7 +23,7 @@ interface FeeRowProps extends StackProps {
   allowCustom?: boolean;
   isSponsored: boolean;
 }
-export function FeesRow(props: FeeRowProps): JSX.Element {
+export function FeesRow(props: FeeRowProps): React.JSX.Element {
   const { fees, isSponsored, allowCustom = true, ...rest } = props;
   const [feeField, _, feeHelper] = useField('fee');
   const [feeCurrencyField] = useField('feeCurrency');

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -16,7 +16,7 @@ import { NetworkModeBadge } from '@app/components/network-mode-badge';
 import { Title } from '@app/components/typography';
 
 interface HeaderProps extends FlexProps {
-  actionButton?: JSX.Element;
+  actionButton?: React.JSX.Element;
   hideActions?: boolean;
   onClose?(): void;
   title?: string;

--- a/src/app/components/inscription-preview-card/components/inscription-metadata.tsx
+++ b/src/app/components/inscription-preview-card/components/inscription-metadata.tsx
@@ -5,7 +5,7 @@ import { Text } from '@app/components/typography';
 interface InscriptionMetadataProps {
   action?(): void;
   actionLabel?: string;
-  icon?: JSX.Element;
+  icon?: React.JSX.Element;
   subtitle: string;
   title: string;
 }

--- a/src/app/components/inscription-preview-card/inscription-preview-card.tsx
+++ b/src/app/components/inscription-preview-card/inscription-preview-card.tsx
@@ -7,8 +7,8 @@ interface InscriptionPreviewCardProps {
   action?(): void;
   actionLabel?: string;
   hideBorder?: boolean;
-  icon?: JSX.Element;
-  image: JSX.Element;
+  icon?: React.JSX.Element;
+  image: React.JSX.Element;
   subtitle: string;
   title: string;
 }

--- a/src/app/components/item-hover.tsx
+++ b/src/app/components/item-hover.tsx
@@ -27,7 +27,7 @@ function ItemHover({
 
 export function usePressable(
   isPressable?: boolean
-): [JSX.Element | null, any, { isHovered: boolean; isFocused: boolean }] {
+): [React.JSX.Element | null, any, { isHovered: boolean; isFocused: boolean }] {
   const [isHovered, bind] = useHover();
   const [isFocused, focusBind] = useFocus();
 

--- a/src/app/components/layout/flag.tsx
+++ b/src/app/components/layout/flag.tsx
@@ -14,7 +14,7 @@ interface FlagProps extends FlexProps {
   spacing?: Spacing;
   align?: 'top' | 'middle' | 'bottom';
   children: React.ReactNode;
-  img: JSX.Element;
+  img: React.JSX.Element;
 }
 /**
  * Implementation of flag object

--- a/src/app/components/link.tsx
+++ b/src/app/components/link.tsx
@@ -10,7 +10,7 @@ export const buildEnterKeyEvent = (onClick: () => void) => {
   };
 };
 
-export function Link(props: BoxProps): JSX.Element {
+export function Link(props: BoxProps): React.JSX.Element {
   const { _hover = {}, children, fontSize = '12px', onClick, ...rest } = props;
   return (
     <Text

--- a/src/app/components/modal-header.tsx
+++ b/src/app/components/modal-header.tsx
@@ -9,7 +9,7 @@ import { NetworkModeBadge } from '@app/components/network-mode-badge';
 import { Title } from '@app/components/typography';
 
 interface ModalHeaderProps extends FlexProps {
-  actionButton?: JSX.Element;
+  actionButton?: React.JSX.Element;
   closeIcon?: boolean;
   hideActions?: boolean;
   onClose?(): void;

--- a/src/app/components/receive/receive-collectible-item.tsx
+++ b/src/app/components/receive/receive-collectible-item.tsx
@@ -8,7 +8,7 @@ import { Caption } from '../typography';
 
 interface ReceiveCollectibleItemProps extends ButtonProps {
   address: string;
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   onCopyAddress(): void;
   title: string;
 }

--- a/src/app/components/sponsored-label.tsx
+++ b/src/app/components/sponsored-label.tsx
@@ -2,7 +2,7 @@ import { FiAlertCircle } from 'react-icons/fi';
 
 import { Box, Stack, Text, color } from '@stacks/ui';
 
-export function SponsoredLabel(): JSX.Element {
+export function SponsoredLabel(): React.JSX.Element {
   return (
     <Stack width="100%">
       <Stack

--- a/src/app/components/text-input-field.tsx
+++ b/src/app/components/text-input-field.tsx
@@ -21,7 +21,7 @@ interface TextInputFieldProps extends FlexProps {
   onClickLabelAction?(): void;
   placeholder?: string;
   inputRef?: Ref<HTMLInputElement>;
-  topInputOverlay?: JSX.Element;
+  topInputOverlay?: React.JSX.Element;
   hasError?: boolean;
 }
 export function TextInputField({

--- a/src/app/components/tx-asset-item.tsx
+++ b/src/app/components/tx-asset-item.tsx
@@ -11,7 +11,7 @@ interface AssetItemProps extends StackProps {
   ticker: string;
 }
 
-export function TxAssetItem(props: AssetItemProps): JSX.Element {
+export function TxAssetItem(props: AssetItemProps): React.JSX.Element {
   const { iconString, amount, ticker, ...rest } = props;
   const imageCanonicalUri = isValidUrl(iconString) ? iconString : undefined;
 

--- a/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction-item.layout.tsx
+++ b/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction-item.layout.tsx
@@ -5,11 +5,11 @@ import { SpaceBetween } from '@app/components/layout/space-between';
 
 interface BitcoinTransactionItemLayoutProps {
   openTxLink(): void;
-  txCaption: JSX.Element;
-  txIcon: JSX.Element;
-  txStatus: JSX.Element;
-  txTitle: JSX.Element;
-  txValue: JSX.Element;
+  txCaption: React.JSX.Element;
+  txIcon: React.JSX.Element;
+  txStatus: React.JSX.Element;
+  txTitle: React.JSX.Element;
+  txValue: React.JSX.Element;
 }
 export function BitcoinTransactionItemLayout({
   openTxLink,

--- a/src/app/features/bitcoin-choose-fee/components/bitcoin-choose-fee.layout.tsx
+++ b/src/app/features/bitcoin-choose-fee/components/bitcoin-choose-fee.layout.tsx
@@ -3,7 +3,7 @@ import { Flex } from '@stacks/ui';
 import { LoadingSpinner } from '@app/components/loading-spinner';
 
 interface BitcoinChooseFeeLayoutProps {
-  children: JSX.Element;
+  children: React.JSX.Element;
   isLoading: boolean;
 }
 

--- a/src/app/features/collectibles/components/_collectible-types/collectible-image.tsx
+++ b/src/app/features/collectibles/components/_collectible-types/collectible-image.tsx
@@ -5,7 +5,7 @@ import { ImageUnavailable } from '../image-unavailable';
 
 interface CollectibleImageProps extends Omit<CollectibleItemLayoutProps, 'children'> {
   alt?: string;
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   src: string;
 }
 export function CollectibleImage(props: CollectibleImageProps) {

--- a/src/app/features/collectibles/components/_collectible-types/collectible-other.tsx
+++ b/src/app/features/collectibles/components/_collectible-types/collectible-other.tsx
@@ -3,7 +3,7 @@ import { Box } from '@stacks/ui';
 import { CollectibleItemLayout, CollectibleItemLayoutProps } from '../collectible-item.layout';
 
 interface CollectibleOtherProps extends Omit<CollectibleItemLayoutProps, 'children'> {
-  children: JSX.Element;
+  children: React.JSX.Element;
 }
 export function CollectibleOther({ children, ...props }: CollectibleOtherProps) {
   return (

--- a/src/app/features/collectibles/components/_collectible-types/collectible-text.tsx
+++ b/src/app/features/collectibles/components/_collectible-types/collectible-text.tsx
@@ -2,7 +2,7 @@ import { CollectibleItemLayout, CollectibleItemLayoutProps } from '../collectibl
 import { CollectibleTextLayout } from './collectible-text.layout';
 
 interface CollectibleTextProps extends Omit<CollectibleItemLayoutProps, 'children'> {
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   content: string;
 }
 export function CollectibleText(props: CollectibleTextProps) {

--- a/src/app/features/collectibles/components/collectible-hover.tsx
+++ b/src/app/features/collectibles/components/collectible-hover.tsx
@@ -4,7 +4,7 @@ import { figmaTheme } from '@app/common/utils/figma-theme';
 import { ArrowIcon } from '@app/components/icons/arrow-icon';
 
 interface CollectibleHoverProps {
-  collectibleTypeIcon?: JSX.Element;
+  collectibleTypeIcon?: React.JSX.Element;
   isHovered: boolean;
   onClickCallToAction?(): void;
 }

--- a/src/app/features/collectibles/components/collectible-item.layout.tsx
+++ b/src/app/features/collectibles/components/collectible-item.layout.tsx
@@ -16,7 +16,7 @@ export interface CollectibleItemLayoutProps {
   onClickCallToAction?(): void;
   onClickLayout?(): void;
   onClickSend?(): void;
-  collectibleTypeIcon?: JSX.Element;
+  collectibleTypeIcon?: React.JSX.Element;
   subtitle: string;
   title: string;
 }

--- a/src/app/features/container/container.layout.tsx
+++ b/src/app/features/container/container.layout.tsx
@@ -1,8 +1,8 @@
 import { Flex, color } from '@stacks/ui';
 
 interface ContainerLayoutProps {
-  children: JSX.Element | JSX.Element[];
-  header: JSX.Element | null;
+  children: React.JSX.Element | React.JSX.Element[];
+  header: React.JSX.Element | null;
 }
 export function ContainerLayout(props: ContainerLayoutProps) {
   const { children, header } = props;

--- a/src/app/features/edit-nonce-drawer/components/edit-nonce-form.tsx
+++ b/src/app/features/edit-nonce-drawer/components/edit-nonce-form.tsx
@@ -7,7 +7,7 @@ interface EditNonceFormProps {
   onClose(): void;
   onSubmit(): void;
 }
-export function EditNonceForm(props: EditNonceFormProps): JSX.Element {
+export function EditNonceForm(props: EditNonceFormProps): React.JSX.Element {
   const { onBlur, onClose, onSubmit } = props;
 
   return (

--- a/src/app/features/increase-fee-drawer/components/fee-multiplier-button.tsx
+++ b/src/app/features/increase-fee-drawer/components/fee-multiplier-button.tsx
@@ -4,7 +4,7 @@ interface FeeMultiplierButtonProps extends ButtonProps {
   multiplier: number;
 }
 
-export function FeeMultiplierButton(props: FeeMultiplierButtonProps): JSX.Element {
+export function FeeMultiplierButton(props: FeeMultiplierButtonProps): React.JSX.Element {
   const { multiplier, ...rest } = props;
 
   return (

--- a/src/app/features/increase-fee-drawer/components/fee-multiplier.tsx
+++ b/src/app/features/increase-fee-drawer/components/fee-multiplier.tsx
@@ -9,7 +9,7 @@ interface FeeMultiplierProps extends StackProps {
   showReset?: boolean;
 }
 
-export function FeeMultiplier(props: FeeMultiplierProps): JSX.Element {
+export function FeeMultiplier(props: FeeMultiplierProps): React.JSX.Element {
   const { onSelectMultiplier, showReset, ...rest } = props;
 
   return (

--- a/src/app/features/increase-fee-drawer/components/increase-fee-field.tsx
+++ b/src/app/features/increase-fee-drawer/components/increase-fee-field.tsx
@@ -11,7 +11,7 @@ import { FeeMultiplier } from './fee-multiplier';
 interface IncreaseFeeFieldProps {
   currentFee: number;
 }
-export function IncreaseFeeField(props: IncreaseFeeFieldProps): JSX.Element {
+export function IncreaseFeeField(props: IncreaseFeeFieldProps): React.JSX.Element {
   const { currentFee } = props;
   const [field, meta, helpers] = useField('fee');
   const [modified, setModified] = useState(false);

--- a/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -39,7 +39,7 @@ interface LedgerSignMsgData {
   unsignedMessage: UnsignedMessage;
 }
 interface LedgerSignMsgDataProps {
-  children({ account, unsignedMessage }: LedgerSignMsgData): JSX.Element;
+  children({ account, unsignedMessage }: LedgerSignMsgData): React.JSX.Element;
 }
 function LedgerSignMsgData({ children }: LedgerSignMsgDataProps) {
   const account = useCurrentStacksAccount();

--- a/src/app/pages/fund/components/fund-account-tile.tsx
+++ b/src/app/pages/fund/components/fund-account-tile.tsx
@@ -4,11 +4,11 @@ import { FundPageSelectors } from '@tests-legacy/page-objects/fund.selectors';
 import { Caption, Title } from '@app/components/typography';
 
 interface FundAccountTileProps {
-  attributes?: JSX.Element;
+  attributes?: React.JSX.Element;
   description: string;
   icon: string;
   onClickTile(): void;
-  receiveStxIcon?: JSX.Element;
+  receiveStxIcon?: React.JSX.Element;
   testId: string;
   title?: string;
 }

--- a/src/app/pages/home/components/tx-button.tsx
+++ b/src/app/pages/home/components/tx-button.tsx
@@ -5,7 +5,7 @@ import { Box, ButtonProps, Text } from '@stacks/ui';
 interface HomeActionButtonProps extends ButtonProps {
   icon: any;
   label: string;
-  buttonComponent(props: ButtonProps): JSX.Element;
+  buttonComponent(props: ButtonProps): React.JSX.Element;
 }
 export const HomeActionButton = memo((props: HomeActionButtonProps) => {
   const { icon, label, buttonComponent: Button, ...rest } = props;

--- a/src/app/pages/home/home.loader.tsx
+++ b/src/app/pages/home/home.loader.tsx
@@ -3,7 +3,7 @@ import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/s
 import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 interface HomeLoaderProps {
-  children(data: StacksAccount): JSX.Element;
+  children(data: StacksAccount): React.JSX.Element;
 }
 export function HomeLoader({ children }: HomeLoaderProps) {
   const currentAccount = useCurrentStacksAccount();

--- a/src/app/pages/onboarding/back-up-secret-key/back-up-secret-key.layout.tsx
+++ b/src/app/pages/onboarding/back-up-secret-key/back-up-secret-key.layout.tsx
@@ -13,10 +13,10 @@ import { Text } from '@app/components/typography';
 import { BackUpSecretKeyActions } from './components/back-up-secret-key-actions';
 
 interface BackUpSecretKeyLayoutProps {
-  secretKeyDisplay: JSX.Element;
+  secretKeyDisplay: React.JSX.Element;
   onBackedUpSecretKey(): void;
 }
-export function BackUpSecretKeyLayout(props: BackUpSecretKeyLayoutProps): JSX.Element {
+export function BackUpSecretKeyLayout(props: BackUpSecretKeyLayoutProps): React.JSX.Element {
   const { secretKeyDisplay, onBackedUpSecretKey } = props;
 
   const [desktopViewport] = useMediaQuery(`(min-width: ${DESKTOP_VIEWPORT_MIN_WIDTH})`);

--- a/src/app/pages/onboarding/back-up-secret-key/components/back-up-secret-key-actions.tsx
+++ b/src/app/pages/onboarding/back-up-secret-key/components/back-up-secret-key-actions.tsx
@@ -9,7 +9,7 @@ import { Caption } from '@app/components/typography';
 interface BackUpSecretKeyLayoutProps {
   onBackedUpSecretKey(): void;
 }
-export function BackUpSecretKeyActions(props: BackUpSecretKeyLayoutProps): JSX.Element {
+export function BackUpSecretKeyActions(props: BackUpSecretKeyLayoutProps): React.JSX.Element {
   const { onBackedUpSecretKey } = props;
 
   return (

--- a/src/app/pages/onboarding/set-password/components/password-strength-indicator.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-strength-indicator.tsx
@@ -8,7 +8,7 @@ import { ValidatedPassword } from '@app/common/validation/validate-password';
 import { defaultColor } from './password-field.utils';
 
 function fillArray(amount: number) {
-  return (item: (i: number) => JSX.Element) =>
+  return (item: (i: number) => React.JSX.Element) =>
     createNullArrayOfLength(amount).map((_, i) => item(i));
 }
 

--- a/src/app/pages/onboarding/welcome/welcome.layout.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.layout.tsx
@@ -37,7 +37,7 @@ interface WelcomeLayoutProps {
   onStartOnboarding(): void;
   onRestoreWallet(): void;
 }
-export function WelcomeLayout(props: WelcomeLayoutProps): JSX.Element {
+export function WelcomeLayout(props: WelcomeLayoutProps): React.JSX.Element {
   const { isGeneratingWallet, onStartOnboarding, onSelectConnectLedger, onRestoreWallet } = props;
 
   return (

--- a/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
+++ b/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
@@ -17,7 +17,7 @@ interface ReceiveTokensLayoutProps {
   accountName?: string;
   onCopyAddressToClipboard(address: string): void;
   title: string;
-  warning?: JSX.Element;
+  warning?: React.JSX.Element;
   hasSubtitle?: boolean;
 }
 export function ReceiveTokensLayout(props: ReceiveTokensLayoutProps) {

--- a/src/app/pages/send/ordinal-inscription/components/collectible-asset.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/collectible-asset.tsx
@@ -4,7 +4,7 @@ import { SpaceBetween } from '@app/components/layout/space-between';
 import { Text } from '@app/components/typography';
 
 interface CollectibleAssetProps {
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   name: string;
   symbol?: string;
 }

--- a/src/app/pages/send/ordinal-inscription/components/send-inscription-loader.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/send-inscription-loader.tsx
@@ -9,7 +9,7 @@ import { createUtxoFromInscription } from './create-utxo-from-inscription';
 import { SendInscriptionContextState } from './send-inscription-container';
 
 interface SendInscriptionLoaderProps {
-  children(data: Partial<SendInscriptionContextState>): JSX.Element;
+  children(data: Partial<SendInscriptionContextState>): React.JSX.Element;
 }
 export function SendInscriptionLoader({ children }: SendInscriptionLoaderProps) {
   const { inscription } = useSendInscriptionRouteState();

--- a/src/app/pages/send/ordinal-inscription/send-indcription-form-loader.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-indcription-form-loader.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@stacks/ui';
 import { LoadingSpinner } from '@app/components/loading-spinner';
 
 interface SendInscriptionFormLoaderProps {
-  children: JSX.Element;
+  children: React.JSX.Element;
   isLoading: boolean;
 }
 

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-field.tsx
@@ -1,4 +1,4 @@
-import { JSX, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useField, useFormikContext } from 'formik';
@@ -15,7 +15,7 @@ interface RecipientFieldProps {
   onBlur?(): void;
   onClickLabelAction?(): void;
   placeholder: string;
-  topInputOverlay?: JSX.Element;
+  topInputOverlay?: React.JSX.Element;
 }
 export function RecipientField({
   isDisabled,

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field-address.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field-address.tsx
@@ -4,7 +4,7 @@ interface RecipientFieldAddressProps {
   isSelectVisible: boolean;
   onClickLabelAction(): void;
   selectedRecipientField: number;
-  topInputOverlay: JSX.Element;
+  topInputOverlay: React.JSX.Element;
 }
 export function RecipientFieldAddress({
   isSelectVisible,

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field-bns-name.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/recipient-field-bns-name.tsx
@@ -15,7 +15,7 @@ interface RecipientFieldBnsNameProps {
   isSelectVisible: boolean;
   onClickLabelAction(): void;
   selectedRecipientField: number;
-  topInputOverlay: JSX.Element;
+  topInputOverlay: React.JSX.Element;
 }
 export function RecipientFieldBnsName({
   fetchFn,

--- a/src/app/pages/send/send-crypto-asset-form/components/selected-asset-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/selected-asset-field.tsx
@@ -5,7 +5,7 @@ import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { SpaceBetween } from '@app/components/layout/space-between';
 
 interface SelectedAssetFieldProps {
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   name: string;
   symbol: string;
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form.tsx
@@ -16,7 +16,7 @@ export function Sip10TokenSendForm() {
 }
 
 interface Sip10TokenSendFormLoaderProps {
-  children: (data: { symbol: string; contractId: string }) => JSX.Element;
+  children: (data: { symbol: string; contractId: string }) => React.JSX.Element;
 }
 
 function Sip10TokenSendFormLoader({ children }: Sip10TokenSendFormLoaderProps) {

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
@@ -29,8 +29,8 @@ interface StacksCommonSendFormProps {
   ): Promise<void>;
   initialValues: StacksSendFormValues;
   validationSchema: ObjectSchema<any>;
-  amountField: JSX.Element;
-  selectedAssetField: JSX.Element;
+  amountField: React.JSX.Element;
+  selectedAssetField: React.JSX.Element;
   availableTokenBalance: Money;
   fees?: Fees;
 }

--- a/src/app/pages/stacks-message-signing-request/components/clarity-value-list.tsx
+++ b/src/app/pages/stacks-message-signing-request/components/clarity-value-list.tsx
@@ -9,7 +9,7 @@ import {
   TupleNodeValueDisplayer,
 } from './nested-tuple-displayer';
 
-function wrapText(text: string): JSX.Element {
+function wrapText(text: string): React.JSX.Element {
   return <>{text}</>;
 }
 

--- a/src/app/pages/transaction-request/components/attachment-row.tsx
+++ b/src/app/pages/transaction-request/components/attachment-row.tsx
@@ -3,7 +3,7 @@ import { useTransactionRequestState } from '@app/store/transactions/requests.hoo
 
 import { Row } from './row';
 
-export function AttachmentRow(): JSX.Element | null {
+export function AttachmentRow(): React.JSX.Element | null {
   const pendingTransaction = useTransactionRequestState();
   return pendingTransaction?.attachment ? (
     <Row name="Attachment" value={hexToHumanReadable(pendingTransaction.attachment)} />

--- a/src/app/pages/transaction-request/components/contract-call-details/function-argument-item.tsx
+++ b/src/app/pages/transaction-request/components/contract-call-details/function-argument-item.tsx
@@ -8,7 +8,7 @@ interface FunctionArgumentProps {
   index: number;
 }
 
-export function FunctionArgumentItem(props: FunctionArgumentProps): JSX.Element {
+export function FunctionArgumentItem(props: FunctionArgumentProps): React.JSX.Element {
   const { arg, index, ...rest } = props;
   const contractFunction = useContractFunction();
   const argCV = deserializeCV(Buffer.from(arg, 'hex'));

--- a/src/app/pages/transaction-request/components/contract-call-details/function-arguments-list.tsx
+++ b/src/app/pages/transaction-request/components/contract-call-details/function-arguments-list.tsx
@@ -8,7 +8,7 @@ import { useTransactionRequestState } from '@app/store/transactions/requests.hoo
 
 import { FunctionArgumentItem } from './function-argument-item';
 
-function FunctionArgumentsListBase(props: StackProps): JSX.Element | null {
+function FunctionArgumentsListBase(props: StackProps): React.JSX.Element | null {
   const transactionRequest = useTransactionRequestState();
 
   if (!transactionRequest || transactionRequest.txType !== 'contract_call') {

--- a/src/app/pages/transaction-request/components/contract-deploy-details/contract-deploy-details.tsx
+++ b/src/app/pages/transaction-request/components/contract-deploy-details/contract-deploy-details.tsx
@@ -14,7 +14,7 @@ import {
 } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 
-function ContractCodeSection(): JSX.Element | null {
+function ContractCodeSection(): React.JSX.Element | null {
   const transactionRequest = useTransactionRequestState();
 
   const currentAccount = useCurrentStacksAccount();
@@ -47,7 +47,7 @@ interface TabButtonProps extends BoxProps {
   isActive: boolean;
 }
 
-function TabButton(props: TabButtonProps): JSX.Element {
+function TabButton(props: TabButtonProps): React.JSX.Element {
   const { isActive, ...rest } = props;
 
   return (
@@ -64,7 +64,7 @@ function TabButton(props: TabButtonProps): JSX.Element {
   );
 }
 
-export function ContractDeployDetails(): JSX.Element | null {
+export function ContractDeployDetails(): React.JSX.Element | null {
   const transactionRequest = useTransactionRequestState();
   const currentAccount = useCurrentStacksAccount();
   const currentAccountStxAddress = useCurrentAccountStxAddressState();

--- a/src/app/pages/transaction-request/components/post-condition-mode-warning.tsx
+++ b/src/app/pages/transaction-request/components/post-condition-mode-warning.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Text, color } from '@stacks/ui';
 
 import { usePostConditionModeState } from '@app/store/transactions/post-conditions.hooks';
 
-export function PostConditionModeWarning(): JSX.Element | null {
+export function PostConditionModeWarning(): React.JSX.Element | null {
   const mode = usePostConditionModeState();
 
   if (mode !== PostConditionMode.Allow) return null;

--- a/src/app/pages/transaction-request/components/post-conditions/fungible-post-condition-item.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/fungible-post-condition-item.tsx
@@ -27,7 +27,7 @@ interface FungiblePostConditionItemProps {
 
 function FungiblePostConditionItemSuspense(
   props: FungiblePostConditionItemProps
-): JSX.Element | null {
+): React.JSX.Element | null {
   const { isLast, pc } = props;
   const currentAccount = useCurrentStacksAccount();
   const pendingTransaction = useTransactionRequestState();
@@ -84,7 +84,9 @@ function FungiblePostConditionItemSuspense(
   );
 }
 
-export function FungiblePostConditionItem(props: FungiblePostConditionItemProps): JSX.Element {
+export function FungiblePostConditionItem(
+  props: FungiblePostConditionItemProps
+): React.JSX.Element {
   return (
     <Suspense fallback={<LoadingSpinner height="190px" />}>
       <FungiblePostConditionItemSuspense {...props} />

--- a/src/app/pages/transaction-request/components/post-conditions/no-post-conditions.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/no-post-conditions.tsx
@@ -5,7 +5,7 @@ import { color } from '@stacks/ui-utils';
 
 import { Body } from '@app/components/typography';
 
-export function NoPostConditions(): JSX.Element {
+export function NoPostConditions(): React.JSX.Element {
   return (
     <Stack alignItems="center" spacing="base" p="base-loose" isInline>
       <Circle bg={color('bg-4')} flexShrink={0}>

--- a/src/app/pages/transaction-request/components/post-conditions/post-condition-item.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/post-condition-item.tsx
@@ -22,7 +22,7 @@ interface PostConditionItemProps {
   pc: STXPostCondition | NonFungiblePostCondition;
 }
 
-function PostConditionItemSuspense(props: PostConditionItemProps): JSX.Element | null {
+function PostConditionItemSuspense(props: PostConditionItemProps): React.JSX.Element | null {
   const { pc, isLast } = props;
   const currentAccount = useCurrentStacksAccount();
   const pendingTransaction = useTransactionRequestState();
@@ -70,7 +70,7 @@ function PostConditionItemSuspense(props: PostConditionItemProps): JSX.Element |
   );
 }
 
-export function PostConditionItem(props: PostConditionItemProps): JSX.Element {
+export function PostConditionItem(props: PostConditionItemProps): React.JSX.Element {
   return (
     <Suspense fallback={<LoadingSpinner height="190px" />}>
       <PostConditionItemSuspense {...props} />

--- a/src/app/pages/transaction-request/components/post-conditions/post-conditions-list.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/post-conditions-list.tsx
@@ -5,7 +5,7 @@ import { useTransactionPostConditions } from '@app/store/transactions/transactio
 import { FungiblePostConditionItem } from './fungible-post-condition-item';
 import { PostConditionItem } from './post-condition-item';
 
-export function PostConditionsList(): JSX.Element {
+export function PostConditionsList(): React.JSX.Element {
   const postConditions = useTransactionPostConditions();
 
   return (

--- a/src/app/pages/transaction-request/components/post-conditions/post-conditions.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/post-conditions.tsx
@@ -14,7 +14,7 @@ import { NoPostConditions } from './no-post-conditions';
 import { PostConditionsList } from './post-conditions-list';
 import { StxPostCondition } from './stx-post-condition';
 
-function PostConditionsSuspense(): JSX.Element | null {
+function PostConditionsSuspense(): React.JSX.Element | null {
   const postConditions = useTransactionPostConditions();
   const mode = usePostConditionModeState();
   const pendingTransaction = useTransactionRequestState();
@@ -48,7 +48,7 @@ function PostConditionsSuspense(): JSX.Element | null {
   );
 }
 
-export function PostConditions(): JSX.Element {
+export function PostConditions(): React.JSX.Element {
   return (
     <Suspense fallback={<></>}>
       <PostConditionsSuspense />

--- a/src/app/pages/transaction-request/components/post-conditions/stx-post-condition.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/stx-post-condition.tsx
@@ -5,7 +5,7 @@ import { stacksValue } from '@app/common/stacks-utils';
 import { EventCard } from '@app/components/event-card';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 
-export function StxPostCondition(): JSX.Element | null {
+export function StxPostCondition(): React.JSX.Element | null {
   const pendingTransaction = useTransactionRequestState();
 
   if (!pendingTransaction || pendingTransaction.txType !== TransactionTypes.STXTransfer)

--- a/src/app/pages/transaction-request/components/row.tsx
+++ b/src/app/pages/transaction-request/components/row.tsx
@@ -6,12 +6,12 @@ import { Caption } from '@app/components/typography';
 import { PrincipalValue } from './principal-value';
 
 interface RowProps extends StackProps {
-  name?: string | JSX.Element | null;
+  name?: string | React.JSX.Element | null;
   type?: string;
   value: string;
 }
 
-export function Row(props: RowProps): JSX.Element {
+export function Row(props: RowProps): React.JSX.Element {
   const { name, type, value, ...rest } = props;
 
   return (

--- a/src/app/pages/transaction-request/components/stx-transfer-details/stx-transfer-details.tsx
+++ b/src/app/pages/transaction-request/components/stx-transfer-details/stx-transfer-details.tsx
@@ -6,7 +6,7 @@ import { AttachmentRow } from '@app/pages/transaction-request/components/attachm
 import { Row } from '@app/pages/transaction-request/components/row';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 
-export function StxTransferDetails(): JSX.Element | null {
+export function StxTransferDetails(): React.JSX.Element | null {
   const pendingTransaction = useTransactionRequestState();
 
   if (!pendingTransaction || pendingTransaction.txType !== 'token_transfer') {

--- a/src/app/pages/transaction-request/components/submit-action.tsx
+++ b/src/app/pages/transaction-request/components/submit-action.tsx
@@ -12,7 +12,7 @@ import { useDrawers } from '@app/common/hooks/use-drawers';
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import { useTransactionError } from '@app/pages/transaction-request/hooks/use-transaction-error';
 
-function BaseConfirmButton(props: ButtonProps): JSX.Element {
+function BaseConfirmButton(props: ButtonProps): React.JSX.Element {
   return (
     <Button borderRadius="10px" mt="base" py="base" type="submit" width="100%" {...props}>
       Confirm

--- a/src/app/pages/transaction-request/components/transaction-error/error-message.tsx
+++ b/src/app/pages/transaction-request/components/transaction-error/error-message.tsx
@@ -7,8 +7,8 @@ import { Caption, Text } from '@app/components/typography';
 
 interface ErrorMessageProps extends StackProps {
   title: string;
-  body: string | JSX.Element;
-  actions?: JSX.Element;
+  body: string | React.JSX.Element;
+  actions?: React.JSX.Element;
 }
 export const ErrorMessage = memo(({ title, body, actions, ...rest }: ErrorMessageProps) => {
   return (

--- a/src/app/pages/update-profile-request/components/profile-box.tsx
+++ b/src/app/pages/update-profile-request/components/profile-box.tsx
@@ -44,7 +44,7 @@ function Properties({ p }: { p: any }) {
   );
 }
 
-export function ProfileBox({ profile }: { profile: Profile }): JSX.Element | null {
+export function ProfileBox({ profile }: { profile: Profile }): React.JSX.Element | null {
   return (
     <Box minHeight={'260px'}>
       <Stack

--- a/src/app/pages/update-profile-request/components/update-action.tsx
+++ b/src/app/pages/update-profile-request/components/update-action.tsx
@@ -57,7 +57,7 @@ export function UpdateAction({
   profileUpdaterPayload,
 }: {
   profileUpdaterPayload: ProfileUpdatePayload;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const { profile: publicProfile } = profileUpdaterPayload;
 
   const { tabId, requestToken } = useProfileUpdateRequestSearchParams();

--- a/src/shared/models/transactions/stacks-transaction.model.ts
+++ b/src/shared/models/transactions/stacks-transaction.model.ts
@@ -18,7 +18,7 @@ export interface FtTransfer {
 
 export interface TxTransferDetails {
   caption: string;
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   link: string;
   title: string;
   value: number | string | null;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5531685437).<!-- Sticky Header Marker -->

## Description
This is a small change to migrate from the deprecated global `JSX` space to `React.JSX`. 

I noticed we get a lot of these warnings:
![Screenshot 2023-07-12 at 13 21 45](https://github.com/hirosystems/wallet/assets/2938440/bc0c1aea-7e0c-4976-bdc2-4f88dd7025c4)

It's not a serious warning but its nice to clean them if we can so more important ones are more noticeable

## Type of Change
- Refactor 
