### PR TITLE
fix: use windows friendly syntax so that yarn dev will launch on wind…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "4.35.0",
   "author": "Hiro Systems PBC",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development concurrently --raw 'node webpack/dev-server.js' 'redux-devtools --hostname=localhost --port=8000'",
+    "dev": "cross-env NODE_ENV=development concurrently --raw \"node webpack/dev-server.js\" \"redux-devtools --hostname=localhost --port=8000\"",
     "dev:test-app": "webpack serve --config test-app/webpack/webpack.config.dev.js",
     "build": "cross-env NODE_ENV=production EXT_ENV=prod webpack --config webpack/webpack.config.prod.js",
     "build:analyze": "cross-env ANALYZE=true NODE_ENV=production EXT_ENV=prod webpack --config webpack/webpack.config.prod.js",


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5533209274).<!-- Sticky Header Marker -->

This change fixes an issue with Windows machines not being able to correctly find `webpack/dev-server.js` and failing to launch as reported here https://github.com/hirosystems/wallet/issues/3966 /

Potential contributors have been unable to run the Wallet on Windows platforms, it fails with:
![252341987-b106ee03-4292-4e08-b04b-5e1ca72e9b8e](https://github.com/hirosystems/wallet/assets/2938440/71a7905a-43a3-43d8-b8a7-76b4cd012488)
