### PR TITLE
fix: stop sign in panel stretching too much, closes #4212

### DIFF
--- a/src/app/pages/onboarding/sign-in/sign-in.tsx
+++ b/src/app/pages/onboarding/sign-in/sign-in.tsx
@@ -91,6 +91,7 @@ export function SignIn() {
       px={['space.05', 'space.05', 'space.11']}
       width="100%"
       gap={['space.03', 'space.09']}
+      height="fit-content"
     >
       <Stack flex="1" gap="space.06">
         <styled.h1 textStyle={['heading.03', 'display.02']}>Sign in with your Secret Key</styled.h1>


### PR DESCRIPTION
> Try out this version of the Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6160525870).<!-- Sticky Header Marker -->

This stops the panel from growing too large. 

https://github.com/leather-wallet/extension/assets/2938440/d3414320-4c23-48e1-8a48-c7b7cadfeff5

It's likely this was introduced by removing some base CSS. 
