### PR TITLE
fix: change to hstack to align buttons, closes #4592

### DIFF
--- a/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
+++ b/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
@@ -1,7 +1,7 @@
 import { toast } from 'react-hot-toast';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Box, Stack } from 'leather-styles/jsx';
+import { Box, HStack, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
 import { Blockchains } from '@shared/models/blockchain.model';
@@ -79,14 +79,14 @@ export function SendInscriptionSummary() {
           <InfoCardRow title="Fee" value={feeRowValue} />
         </Stack>
 
-        <Stack gap="space.04" width="100%">
+        <HStack gap="space.04" width="100%">
           <InfoCardBtn
             onClick={onClickLink}
             icon={<ExternalLinkIcon size="14px" />}
             label="View details"
           />
           <InfoCardBtn onClick={onClickCopy} icon={<CopyIcon size="14px" />} label="Copy ID" />
-        </Stack>
+        </HStack>
       </InfoCard>
     </BaseDrawer>
   );


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7085705932).<!-- Sticky Header Marker -->

This PR changes the `sent-inscription-summary` to use `HStack` instead of `Stack` to get the buttons lined up correctly.

![Screenshot 2023-12-04 at 11 07 06](https://github.com/leather-wallet/extension/assets/2938440/99383b75-916e-48cf-ac3d-b1b07b2b645e)
