### PR TITLE
fix: use nakamoto testnet link when network is set to nakamoto testnet

### DIFF
--- a/src/app/common/hooks/use-stacks-explorer-link.ts
+++ b/src/app/common/hooks/use-stacks-explorer-link.ts
@@ -6,17 +6,19 @@ import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 import { openInNewTab } from '../utils/open-in-new-tab';
 
 export interface HandleOpenStacksTxLinkArgs {
-  suffix?: string;
+  searchParams?: URLSearchParams;
   txid: string;
 }
 export function useStacksExplorerLink() {
-  const { mode } = useCurrentNetworkState();
+  const { mode, isNakamotoTestnet } = useCurrentNetworkState();
 
   const handleOpenStacksTxLink = useCallback(
-    ({ suffix, txid }: HandleOpenStacksTxLinkArgs) => {
-      openInNewTab(makeStacksTxExplorerLink({ mode, suffix, txid }));
+    ({ searchParams, txid }: HandleOpenStacksTxLinkArgs) => {
+      openInNewTab(
+        makeStacksTxExplorerLink({ mode, searchParams, isNakamoto: isNakamotoTestnet, txid })
+      );
     },
-    [mode]
+    [mode, isNakamotoTestnet]
   );
 
   return {

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -2,7 +2,13 @@ import { hexToBytes } from '@stacks/common';
 import { BytesReader, PostCondition, deserializePostCondition } from '@stacks/transactions';
 import { toUnicode } from 'punycode';
 
-import { BitcoinChainConfig, BitcoinNetworkModes, KEBAB_REGEX } from '@shared/constants';
+import {
+  BitcoinChainConfig,
+  BitcoinNetworkModes,
+  HIRO_API_BASE_URL_NAKAMOTO_TESTNET,
+  HIRO_EXPLORER_URL,
+  KEBAB_REGEX,
+} from '@shared/constants';
 import { isBoolean } from '@shared/utils';
 
 export function createNullArrayOfLength(length: number) {
@@ -41,16 +47,42 @@ interface MakeBitcoinTxExplorerLinkArgs {
 
 interface MakeStacksTxExplorerLinkArgs {
   mode: BitcoinNetworkModes;
-  suffix?: string;
+  searchParams?: URLSearchParams;
   txid: string;
+  isNakamoto?: boolean;
 }
 
 export function makeStacksTxExplorerLink({
   mode,
-  suffix = '',
+  searchParams = new URLSearchParams(),
   txid,
+  isNakamoto = false,
 }: MakeStacksTxExplorerLinkArgs) {
-  return `https://explorer.hiro.so/txid/${txid}?chain=${mode}${suffix}`;
+  searchParams.append('chain', mode);
+  if (isNakamoto) {
+    searchParams.append('api', HIRO_API_BASE_URL_NAKAMOTO_TESTNET);
+  }
+  return `${HIRO_EXPLORER_URL}/txid/${txid}?${searchParams.toString()}`;
+}
+
+interface MakeStacksAddressExplorerLinkArgs {
+  mode: BitcoinNetworkModes;
+  searchParams?: URLSearchParams;
+  address: string;
+  isNakamoto?: boolean;
+}
+
+export function makeStacksAddressExplorerLink({
+  mode,
+  searchParams = new URLSearchParams(),
+  address,
+  isNakamoto = false,
+}: MakeStacksAddressExplorerLinkArgs) {
+  searchParams.append('chain', mode);
+  if (isNakamoto) {
+    searchParams.append('api', HIRO_API_BASE_URL_NAKAMOTO_TESTNET);
+  }
+  return `${HIRO_EXPLORER_URL}/address/${address}?${searchParams.toString()}`;
 }
 
 export function makeBitcoinTxExplorerLink({

--- a/src/app/components/stacks-transaction-item/stacks-transaction-item.tsx
+++ b/src/app/components/stacks-transaction-item/stacks-transaction-item.tsx
@@ -31,7 +31,7 @@ export function StacksTransactionItem({
   transferDetails,
   transaction,
 }: StacksTransactionItemProps) {
-  const { handleOpenStacksTxLink: handleOpenTxLink } = useStacksExplorerLink();
+  const { handleOpenStacksTxLink } = useStacksExplorerLink();
   const currentAccount = useCurrentStacksAccount();
   const analytics = useAnalytics();
   const [_, setRawTxId] = useRawTxIdState();
@@ -43,7 +43,7 @@ export function StacksTransactionItem({
 
   const openTxLink = () => {
     void analytics.track('view_transaction');
-    handleOpenTxLink({
+    handleOpenStacksTxLink({
       txid: transaction?.tx_id || transferDetails?.link || '',
     });
   };

--- a/src/app/features/activity-list/components/submitted-transaction-list/submitted-transaction-item.tsx
+++ b/src/app/features/activity-list/components/submitted-transaction-list/submitted-transaction-item.tsx
@@ -18,7 +18,7 @@ interface SubmittedTransactionItemProps {
 }
 export function SubmittedTransactionItem({ transaction, txId }: SubmittedTransactionItemProps) {
   const [component, bind] = usePressable(true);
-  const { handleOpenStacksTxLink: handleOpenTxLink } = useStacksExplorerLink();
+  const { handleOpenStacksTxLink } = useStacksExplorerLink();
 
   if (!transaction) return null;
 
@@ -37,8 +37,8 @@ export function SubmittedTransactionItem({ transaction, txId }: SubmittedTransac
       <HStack
         alignItems="center"
         onClick={() =>
-          handleOpenTxLink({
-            suffix: `&submitted=true`,
+          handleOpenStacksTxLink({
+            searchParams: new URLSearchParams('&submitted=true'),
             txid: txId,
           })
         }

--- a/src/app/features/stacks-transaction-request/contract-call-details/contract-call-details.tsx
+++ b/src/app/features/stacks-transaction-request/contract-call-details/contract-call-details.tsx
@@ -13,7 +13,7 @@ import { FunctionArgumentsList } from './function-arguments-list';
 
 function ContractCallDetailsSuspense() {
   const transactionRequest = useTransactionRequestState();
-  const { handleOpenStacksTxLink: handleOpenTxLink } = useStacksExplorerLink();
+  const { handleOpenStacksTxLink } = useStacksExplorerLink();
 
   if (!transactionRequest || transactionRequest.txType !== 'contract_call') return null;
   const { contractAddress, contractName, functionName, attachment } = transactionRequest;
@@ -33,7 +33,7 @@ function ContractCallDetailsSuspense() {
 
       <ContractPreviewLayout
         onClick={() =>
-          handleOpenTxLink({
+          handleOpenStacksTxLink({
             txid: formatContractId(contractAddress, contractName),
           })
         }

--- a/src/app/features/stacks-transaction-request/principal-value.tsx
+++ b/src/app/features/stacks-transaction-request/principal-value.tsx
@@ -1,3 +1,4 @@
+import { makeStacksAddressExplorerLink } from '@app/common/utils';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 import { Link } from '@app/ui/components/link/link';
@@ -7,11 +8,15 @@ interface PrincipalValueProps {
 }
 export function PrincipalValue(props: PrincipalValueProps) {
   const { address } = props;
-  const { mode } = useCurrentNetworkState();
+  const { mode, isNakamotoTestnet } = useCurrentNetworkState();
 
   return (
     <Link
-      onClick={() => openInNewTab(`https://explorer.hiro.so/address/${address}?chain=${mode}`)}
+      onClick={() =>
+        openInNewTab(
+          makeStacksAddressExplorerLink({ mode, address, isNakamoto: isNakamotoTestnet })
+        )
+      }
       size="sm"
       variant="text"
       wordBreak="break-all"

--- a/src/app/pages/send/sent-summary/stx-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/stx-sent-summary.tsx
@@ -41,11 +41,11 @@ export function StxSentSummary() {
   } = state;
 
   const { onCopy } = useClipboard(txId || '');
-  const { handleOpenStacksTxLink: handleOpenTxLink } = useStacksExplorerLink();
+  const { handleOpenStacksTxLink } = useStacksExplorerLink();
 
   function onClickLink() {
     void analytics.track('view_transaction_confirmation', { symbol: 'STX' });
-    handleOpenTxLink(txLink);
+    handleOpenStacksTxLink(txLink);
   }
 
   function onClickCopy() {

--- a/src/app/store/networks/networks.hooks.ts
+++ b/src/app/store/networks/networks.hooks.ts
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { StacksNetwork } from '@stacks/network';
 import { ChainID, TransactionVersion } from '@stacks/transactions';
 
-import { NetworkModes } from '@shared/constants';
+import { HIRO_API_BASE_URL_NAKAMOTO_TESTNET, NetworkModes } from '@shared/constants';
 import { whenStacksChainId } from '@shared/crypto/stacks/stacks.utils';
 
 import { useAppDispatch } from '@app/store';
@@ -18,8 +18,10 @@ export function useCurrentNetworkState() {
 
   return useMemo(() => {
     const isTestnet = currentNetwork.chain.stacks.chainId === ChainID.Testnet;
+    const isNakamotoTestnet =
+      currentNetwork.chain.stacks.url === HIRO_API_BASE_URL_NAKAMOTO_TESTNET;
     const mode = (isTestnet ? 'testnet' : 'mainnet') as NetworkModes;
-    return { ...currentNetwork, isTestnet, mode };
+    return { ...currentNetwork, isTestnet, isNakamotoTestnet, mode };
   }, [currentNetwork]);
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -80,8 +80,10 @@ export const BESTINSLOT_API_BASE_URL_TESTNET = 'https://leatherapi_testnet.besti
 
 export const STX20_API_BASE_URL_MAINNET = 'https://api.stx20.com/api/v1';
 
+export const HIRO_EXPLORER_URL = 'https://explorer.hiro.so';
 export const HIRO_API_BASE_URL_MAINNET = 'https://api.hiro.so';
 export const HIRO_API_BASE_URL_TESTNET = 'https://api.testnet.hiro.so';
+export const HIRO_API_BASE_URL_NAKAMOTO_TESTNET = 'https://api.nakamoto.testnet.hiro.so';
 export const HIRO_INSCRIPTIONS_API_URL = 'https://api.hiro.so/ordinals/v1/inscriptions';
 
 export const BITCOIN_API_BASE_URL_MAINNET = 'https://blockstream.info/api';


### PR DESCRIPTION
> Try out Leather build 793aa09 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9063263185), [Test report](https://leather-wallet.github.io/playwright-reports/fix/nakamoto-testnet-link), [Storybook](https://fix-nakamoto-testnet-link--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/nakamoto-testnet-link)<!-- Sticky Header Marker -->

Derive if network is currently a nakamoto testnet by checking it with stacks url: `https://api.nakamoto.testnet.hiro.so`
Then add a search param to hiro explorer urls if current network is set to nakamoto testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced link generation for Stacks transactions with new parameters for better user navigation.
  - Added new constants for enhanced connectivity with HIRO API and Explorer services, improving network interactions.

- **Refactor**
  - Updated various components to utilize improved link generation functions, ensuring consistency across the application.
  - Renamed function handlers in components for clarity and better integration.

- **Bug Fixes**
  - Adjusted handling of transaction links in UI components to ensure they open correctly with new parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->