### PR TITLE
feat: add query error analytics

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
+import path from 'path';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import Webpack from 'webpack';
 
@@ -84,6 +85,7 @@ const config: StorybookConfig = {
     config.plugins.push(
       new Webpack.ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],
+        chrome: [path.join(__dirname, '../tests/mocks/mock-chrome.ts'), 'chrome'],
       })
     );
     return config;

--- a/src/app/common/hooks/analytics/use-analytics.ts
+++ b/src/app/common/hooks/analytics/use-analytics.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 
+import type { NetworkConfiguration } from '@leather-wallet/models';
 import {
   EventParams,
   PageParams,
@@ -13,7 +13,10 @@ import { analytics, initAnalytics } from '@shared/utils/analytics';
 
 import { flow, origin } from '@app/common/initial-search-params';
 import { useWalletType } from '@app/common/use-wallet-type';
+import { store } from '@app/store';
+import { type WalletType, selectWalletType } from '@app/store/common/wallet-type.selectors';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
+import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 const IGNORED_PATH_REGEXPS = [/^\/$/];
 
@@ -32,48 +35,72 @@ export function useInitalizeAnalytics() {
   }, []);
 }
 
+function getStateProps() {
+  const state = store.getState();
+  const currentNetwork = selectCurrentNetwork(state);
+  const walletType = selectWalletType(state);
+
+  return {
+    walletType,
+    currentNetwork,
+  };
+}
+
+interface Analytics {
+  identify(properties: object): Promise<unknown>;
+  page(...args: PageParams): Promise<unknown>;
+  track(...args: EventParams): Promise<unknown>;
+}
+
+export function createAnalytics(suppliedOptions?: {
+  currentNetwork: NetworkConfiguration;
+  walletType?: WalletType;
+}): Analytics {
+  const options = suppliedOptions ?? getStateProps();
+  const defaultProperties = {
+    network: options.currentNetwork.name.toLowerCase(),
+    usingDefaultHiroApi: isHiroApiUrl(options.currentNetwork.chain.stacks.url),
+    route: location.pathname,
+    version: VERSION,
+    walletType: options.walletType,
+    ...(flow && { flow }),
+    ...(origin && { origin }),
+  };
+
+  const defaultOptions = { context: { ip: '0.0.0.0' } };
+
+  return {
+    async identify(properties) {
+      return analytics.identify(properties).catch(logger.error);
+    },
+
+    async page(...args) {
+      const [category, name, properties, options, ...rest] = args;
+      const prop = { ...defaultProperties, ...properties };
+      const opts = { ...defaultOptions, ...options };
+      logger.debug(`Analytics page view: ${name}`, properties);
+
+      if (typeof name === 'string' && isIgnoredPath(name)) return;
+
+      return analytics.page(category, name, prop, opts, ...rest).catch(logger.error);
+    },
+
+    async track(...args) {
+      const [eventName, properties, options, ...rest] = args;
+      const prop = { ...defaultProperties, ...properties };
+      const opts = { ...defaultOptions, ...options };
+      logger.debug(`Analytics event: ${eventName}`, properties);
+      return analytics.track(eventName, prop, opts, ...rest).catch(logger.error);
+    },
+  };
+}
+
 export function useAnalytics() {
   const currentNetwork = useCurrentNetworkState();
-  const location = useLocation();
   const { walletType } = useWalletType();
 
-  return useMemo(() => {
-    const defaultProperties = {
-      network: currentNetwork.name.toLowerCase(),
-      usingDefaultHiroApi: isHiroApiUrl(currentNetwork.chain.stacks.url),
-      route: location.pathname,
-      version: VERSION,
-      walletType,
-      ...(flow && { flow }),
-      ...(origin && { origin }),
-    };
-
-    const defaultOptions = { context: { ip: '0.0.0.0' } };
-
-    return {
-      async identify(properties: object) {
-        return analytics.identify(properties).catch(logger.error);
-      },
-
-      async page(...args: PageParams) {
-        const [category, name, properties, options, ...rest] = args;
-        const prop = { ...defaultProperties, ...properties };
-        const opts = { ...defaultOptions, ...options };
-        logger.debug(`Analytics page view: ${name}`, properties);
-
-        if (typeof name === 'string' && isIgnoredPath(name)) return;
-
-        return analytics.page(category, name, prop, opts, ...rest).catch(logger.error);
-      },
-
-      async track(...args: EventParams) {
-        const [eventName, properties, options, ...rest] = args;
-        const prop = { ...defaultProperties, ...properties };
-        const opts = { ...defaultOptions, ...options };
-        logger.debug(`Analytics event: ${eventName}`, properties);
-
-        return analytics.track(eventName, prop, opts, ...rest).catch(logger.error);
-      },
-    };
-  }, [currentNetwork.chain.stacks.url, currentNetwork.name, location.pathname, walletType]);
+  return useMemo(
+    () => createAnalytics({ currentNetwork, walletType }),
+    [currentNetwork, walletType]
+  );
 }

--- a/src/app/common/use-wallet-type.ts
+++ b/src/app/common/use-wallet-type.ts
@@ -1,24 +1,18 @@
 import { useMemo } from 'react';
 
-import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
-import { useCurrentKeyDetails } from '@app/store/software-keys/software-key.selectors';
+import { type WalletType, useWalletTypeSelector } from '@app/store/common/wallet-type.selectors';
 
-enum WalletType {
-  Ledger = 'ledger',
-  Software = 'software',
-}
-
-function isLedgerWallet(walletType: WalletType) {
+function isLedgerWallet(walletType?: WalletType) {
   return walletType === 'ledger';
 }
 
-function isSoftwareWallet(walletType: WalletType) {
+function isSoftwareWallet(walletType?: WalletType) {
   return walletType === 'software';
 }
 
 type WalletTypeMap<T> = Record<WalletType, T>;
 
-function whenWallet(walletType: WalletType) {
+function whenWallet(walletType?: WalletType) {
   return <T extends WalletTypeMap<unknown>>(walletTypeMap: T) => {
     if (isLedgerWallet(walletType)) return walletTypeMap.ledger as T[WalletType.Ledger];
     if (isSoftwareWallet(walletType)) return walletTypeMap.software as T[WalletType.Software];
@@ -27,19 +21,7 @@ function whenWallet(walletType: WalletType) {
 }
 
 export function useWalletType() {
-  const wallet = useCurrentKeyDetails();
-  const isLedger = useHasLedgerKeys();
-
-  // Any type here allows use within app without handling undefined
-  // case will error when use within onboarding
-  let walletType: any;
-
-  if (wallet?.encryptedSecretKey) {
-    walletType = WalletType.Software;
-  }
-  if (isLedger) {
-    walletType = WalletType.Ledger;
-  }
+  const walletType = useWalletTypeSelector();
 
   return useMemo(
     () => ({

--- a/src/app/store/common/wallet-type.selectors.ts
+++ b/src/app/store/common/wallet-type.selectors.ts
@@ -1,0 +1,30 @@
+import { useSelector } from 'react-redux';
+
+import { createSelector } from '@reduxjs/toolkit';
+
+import { selectHasLedgerKeys } from '../ledger/ledger.selectors';
+import { selectHasSecretKey } from '../software-keys/software-key.selectors';
+
+export enum WalletType {
+  Ledger = 'ledger',
+  Software = 'software',
+}
+
+export const selectWalletType = createSelector(
+  selectHasLedgerKeys,
+  selectHasSecretKey,
+  (hasLedgerKeys, hasSecretKey) => {
+    if (hasSecretKey) {
+      return WalletType.Software;
+    }
+    if (hasLedgerKeys) {
+      return WalletType.Ledger;
+    }
+    // TODO: better error handling
+    return undefined;
+  }
+);
+
+export function useWalletTypeSelector() {
+  return useSelector(selectWalletType);
+}

--- a/src/app/store/ledger/ledger.selectors.ts
+++ b/src/app/store/ledger/ledger.selectors.ts
@@ -11,12 +11,12 @@ const selectNumberOfLedgerKeysPersisted = createSelector(selectLedger, ledger =>
   sumNumbers(Object.values(ledger).map(chain => Object.keys(chain.entities).length))
 );
 
-function useNumberOfLedgerKeysPersisted() {
-  return useSelector(selectNumberOfLedgerKeysPersisted);
-}
+export const selectHasLedgerKeys = createSelector(selectNumberOfLedgerKeysPersisted, numOfKeys =>
+  numOfKeys.isGreaterThan(0)
+);
 
 export function useHasLedgerKeys() {
-  return useNumberOfLedgerKeysPersisted().isGreaterThan(0);
+  return useSelector(selectHasLedgerKeys);
 }
 
 export function useLedgerDeviceTargetId() {

--- a/src/app/store/software-keys/software-key.selectors.ts
+++ b/src/app/store/software-keys/software-key.selectors.ts
@@ -17,6 +17,11 @@ export const selectDefaultSoftwareKey = createSelector(
   state => state.entities[defaultWalletKeyId]
 );
 
+export const selectHasSecretKey = createSelector(
+  selectDefaultSoftwareKey,
+  softwareKey => !!softwareKey?.encryptedSecretKey
+);
+
 export function useCurrentKeyDetails() {
   return useSelector(selectDefaultSoftwareKey);
 }

--- a/tests/mocks/mock-chrome.ts
+++ b/tests/mocks/mock-chrome.ts
@@ -1,0 +1,18 @@
+export const chrome = {
+  storage: {
+    local: {
+      clear() {},
+      get() {},
+      getBytesInUse() {},
+      onChanged() {},
+      remove() {},
+      set() {},
+    },
+  },
+  tabs: {
+    sendMessage() {},
+  },
+  runtime: {
+    sendMessage() {},
+  },
+};


### PR DESCRIPTION
> Try out Leather build 10272bd — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9255004480), [Test report](https://leather-wallet.github.io/playwright-reports/feat-add-query-error-analytics), [Storybook](https://feat-add-query-error-analytics--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-add-query-error-analytics)<!-- Sticky Header Marker -->

using QueryCache and MutationCache, send analytics events when queries or mutations fail using their queryKey and mutationKey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced error handling and tracking for analytics.
  - Added new functionality to check for encrypted secret keys in software keys.

- **Refactor**
  - Simplified and optimized wallet type determination logic.
  - Updated analytics handling within the app for better performance and reliability.

- **Bug Fixes**
  - Improved error handling for queries and mutations to ensure smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->