### PR TITLE
feat: add runes fiat balance, closes #5300

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@leather.io/constants": "0.8.1",
     "@leather.io/crypto": "1.0.3",
     "@leather.io/models": "0.10.1",
-    "@leather.io/query": "0.10.2",
+    "@leather.io/query": "0.11.1",
     "@leather.io/tokens": "0.6.1",
     "@leather.io/ui": "1.6.3",
     "@leather.io/utils": "0.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 0.10.1
         version: 0.10.1
       '@leather.io/query':
-        specifier: 0.10.2
-        version: 0.10.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
+        specifier: 0.11.1
+        version: 0.11.1(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
       '@leather.io/tokens':
         specifier: 0.6.1
         version: 0.6.1
@@ -2898,8 +2898,8 @@ packages:
   '@leather.io/prettier-config@0.5.0':
     resolution: {integrity: sha512-Pul+4MAyBKnQvqgcKJLbZl4DHnS4kCJzSuaYFW6cfHdre7BFn/iY6Er/Dvm9F8g7VMtkdYu68jEYxQ1Xc7A0KQ==}
 
-  '@leather.io/query@0.10.2':
-    resolution: {integrity: sha512-Fikei979AsZkLvO1boUQkJJOlVcHf9NZvSvFnvgTlaqZA3HAwLykeNkHyrSca359jiC3Xi7Ie+wH/RcFsh11AQ==}
+  '@leather.io/query@0.11.1':
+    resolution: {integrity: sha512-lrjfKo5+70FSijrFCOgkK08K14OUy/b58lfu+IDXO2higm4Qqo1Af0+L8Jtm5CMRTbdcvRicP/+ssaAK9lGoOA==}
     peerDependencies:
       react: '*'
 
@@ -17586,7 +17586,7 @@ snapshots:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/query@0.10.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
+  '@leather.io/query@0.11.1(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
     dependencies:
       '@fungible-systems/zone-file': 2.0.0
       '@hirosystems/token-metadata-api-client': 1.2.0(encoding@0.1.13)

--- a/src/app/components/loaders/runes-loader.tsx
+++ b/src/app/components/loaders/runes-loader.tsx
@@ -1,9 +1,11 @@
-import type { CryptoAssetBalance, RuneCryptoAssetInfo } from '@leather.io/models';
+import type { CryptoAssetBalance, MarketData, RuneCryptoAssetInfo } from '@leather.io/models';
 import { useRuneTokens } from '@leather.io/query';
 
 interface RunesLoaderProps {
   addresses: string[];
-  children(runes: { balance: CryptoAssetBalance; info: RuneCryptoAssetInfo }[]): React.ReactNode;
+  children(
+    runes: { balance: CryptoAssetBalance; info: RuneCryptoAssetInfo; marketData: MarketData }[]
+  ): React.ReactNode;
 }
 export function RunesLoader({ addresses, children }: RunesLoaderProps) {
   const { runes = [] } = useRuneTokens(addresses);

--- a/src/app/features/asset-list/bitcoin/runes-asset-list/runes-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/runes-asset-list/runes-asset-list.tsx
@@ -1,17 +1,20 @@
-import type { CryptoAssetBalance, RuneCryptoAssetInfo } from '@leather.io/models';
+import type { CryptoAssetBalance, MarketData, RuneCryptoAssetInfo } from '@leather.io/models';
 import { RunesAvatarIcon } from '@leather.io/ui';
 import { convertAmountToBaseUnit, createMoneyFromDecimal } from '@leather.io/utils';
 
+import { convertAssetBalanceToFiat } from '@app/common/asset-utils';
 import { CryptoAssetItemLayout } from '@app/components/crypto-asset-item/crypto-asset-item.layout';
 
 interface RuneTokenAssetDetails {
   balance: CryptoAssetBalance;
   info: RuneCryptoAssetInfo;
+  marketData: MarketData;
 }
 
 interface RunesAssetListProps {
   runes: RuneTokenAssetDetails[];
 }
+
 export function RunesAssetList({ runes }: RunesAssetListProps) {
   return runes.map((rune, i) => (
     <CryptoAssetItemLayout
@@ -25,6 +28,10 @@ export function RunesAssetList({ runes }: RunesAssetListProps) {
       icon={<RunesAvatarIcon />}
       key={`${rune.info.symbol}${i}`}
       titleLeft={rune.info.spacedRuneName ?? rune.info.runeName}
+      fiatBalance={convertAssetBalanceToFiat({
+        balance: rune.balance.availableBalance,
+        marketData: rune.marketData,
+      })}
     />
   ));
 }


### PR DESCRIPTION
> Try out Leather build 77c63eb — [Extension build](https://github.com/leather-io/extension/actions/runs/9959764438), [Test report](https://leather-io.github.io/playwright-reports/feat-runes-fiat), [Storybook](https://feat-runes-fiat--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-runes-fiat)<!-- Sticky Header Marker -->

This pr adds fiat balance to runes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `RunesLoader` and `RunesAssetList` components to include market data, providing more comprehensive asset information.
  - Introduced fiat balance display for assets in the `RunesAssetList`, giving users a clearer understanding of the asset values in fiat currency.

- **Dependencies**
  - Updated `@leather.io/query` from version 0.10.2 to 0.11.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->