### PR TITLE
fix: stx fallback btn show on load

### DIFF
--- a/src/app/features/asset-list/asset-list.tsx
+++ b/src/app/features/asset-list/asset-list.tsx
@@ -20,6 +20,8 @@ import { RunesAssetList } from '@app/features/asset-list/bitcoin/runes-asset-lis
 import { Src20TokenAssetList } from '@app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list';
 import { Stx20TokenAssetList } from '@app/features/asset-list/stacks/stx20-token-asset-list/stx20-token-asset-list';
 import { StxCryptoAssetItem } from '@app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item';
+import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
 
 import { ConnectLedgerAssetItemFallback } from './_components/connect-ledger-asset-item-fallback';
 import { BtcCryptoAssetItem } from './bitcoin/btc-crypto-asset-item/btc-crypto-asset-item';
@@ -34,6 +36,8 @@ interface AssetListProps {
 }
 export function AssetList({ onSelectAsset, variant = 'read-only' }: AssetListProps) {
   const { whenWallet } = useWalletType();
+  const currentAccount = useCurrentStacksAccount();
+  const isLedger = useHasLedgerKeys();
 
   const isReadOnly = variant === 'read-only';
 
@@ -65,12 +69,14 @@ export function AssetList({ onSelectAsset, variant = 'read-only' }: AssetListPro
 
       <CurrentStacksAccountLoader
         fallback={
-          <ConnectLedgerAssetItemFallback
-            chain="stacks"
-            icon={<StxAvatarIcon />}
-            symbol="STX"
-            variant={variant}
-          />
+          !currentAccount && !isLedger ? null : (
+            <ConnectLedgerAssetItemFallback
+              chain="stacks"
+              icon={<StxAvatarIcon />}
+              symbol="STX"
+              variant={variant}
+            />
+          )
         }
       >
         {account => (


### PR DESCRIPTION
> Try out Leather build b13d6e3 — [Extension build](https://github.com/leather-io/extension/actions/runs/10008869725), [Test report](https://leather-io.github.io/playwright-reports/fix-fallback-stx), [Storybook](https://fix-fallback-stx--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-fallback-stx)<!-- Sticky Header Marker -->

`useAtomValue(stacksAccountState)` initially returns empty array on page load, it leads to short display of `Connect Stacks` btn (which we show in btc only ledger mode)

I believe we need to refactor this and remove usage of atom?
but for now it's prob better just to hide stacks row rather than show fallback btn
wdyt?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `AssetList` component to conditionally display content based on the user's active Stacks account and Ledger key availability.
  
- **Bug Fixes**
	- Improved user experience by preventing unnecessary rendering of the fallback component when no active account or Ledger keys are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->