### PR TITLE
fix: send inscription flow validation error

### DIFF
--- a/src/app/pages/send/ordinal-inscription/components/create-utxo-from-inscription.ts
+++ b/src/app/pages/send/ordinal-inscription/components/create-utxo-from-inscription.ts
@@ -17,7 +17,7 @@ export function createUtxoFromInscription({
   const { genesisBlockHash, genesisTimestamp, genesisBlockHeight, value } = inscription;
   return {
     txid: inscription.txid,
-    vout: Number(inscription.output.split(':')[1]),
+    vout: Number(inscription.output),
     status: {
       confirmed: true,
       block_height: genesisBlockHeight,


### PR DESCRIPTION
> Try out Leather build 106de08 — [Extension build](https://github.com/leather-io/extension/actions/runs/10077171578), [Test report](https://leather-io.github.io/playwright-reports/fix-inscription-send-flow), [Storybook](https://fix-inscription-send-flow--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-inscription-send-flow)<!-- Sticky Header Marker -->

There is a bug in send inscription flow validation due to migration to BiS api. [link to code](https://github.com/leather-io/mono/blob/e580597099500397fcd9d3161c3168bed546bb26/packages/query/src/bitcoin/ordinals/inscription.utils.ts#L38)
In output we return just index now


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified the calculation of the `vout` property for better accuracy in determining output values, enhancing the reliability of the output interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->