### PR TITLE
fix: inscription send error state layout

### DIFF
--- a/src/app/pages/send/broadcast-error/broadcast-error.tsx
+++ b/src/app/pages/send/broadcast-error/broadcast-error.tsx
@@ -1,15 +1,24 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import get from 'lodash.get';
 
+import { Dialog } from '@leather.io/ui';
+
+import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
 
 import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { DialogHeader } from '@app/ui/components/containers/headers/dialog-header';
 
 import { BroadcastErrorLayout } from './components/broadcast-error.layout';
 
-export function BroadcastError() {
+interface Props {
+  showInDialog?: boolean;
+}
+
+export function BroadcastError({ showInDialog = false }: Props) {
   const { state } = useLocation();
+  const navigate = useNavigate();
 
   const msg = get(state, 'error.message', 'Unknown error response');
   const title = get(state, 'title', 'There was an error broadcasting your transaction');
@@ -17,7 +26,7 @@ export function BroadcastError() {
 
   useOnMount(() => void analytics.track('bitcoin_contract_error', { msg }));
 
-  return (
+  const layout = (
     <BroadcastErrorLayout
       my="space.05"
       textAlign="center"
@@ -26,4 +35,18 @@ export function BroadcastError() {
       body={body}
     />
   );
+
+  if (showInDialog) {
+    return (
+      <Dialog
+        header={<DialogHeader title="Error" />}
+        isShowing
+        onClose={() => navigate(RouteUrls.Home)}
+      >
+        {layout}
+      </Dialog>
+    );
+  }
+
+  return layout;
 }

--- a/src/app/pages/send/ordinal-inscription/ordinal-routes.tsx
+++ b/src/app/pages/send/ordinal-inscription/ordinal-routes.tsx
@@ -21,6 +21,6 @@ export const sendOrdinalRoutes = (
     <Route path={RouteUrls.SendOrdinalInscriptionReview} element={<SendInscriptionReview />} />
 
     <Route path={RouteUrls.SendOrdinalInscriptionSent} element={<SendInscriptionSummary />} />
-    <Route path={RouteUrls.SendOrdinalInscriptionError} element={<BroadcastError />} />
+    <Route path={RouteUrls.SendOrdinalInscriptionError} element={<BroadcastError showInDialog />} />
   </Route>
 );


### PR DESCRIPTION
> Try out Leather build 53d8898 — [Extension build](https://github.com/leather-io/extension/actions/runs/10140859528), [Test report](https://leather-io.github.io/playwright-reports/fix-inscription-error-layout), [Storybook](https://fix-inscription-error-layout--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-inscription-error-layout)<!-- Sticky Header Marker -->

This pr fixes inscription send error state layout:
![Screenshot 2024-07-29 at 12 31 02](https://github.com/user-attachments/assets/5343ee0e-4542-410b-bb74-3db9d29cb738)
