### PR TITLE
fix: switch account modal ui bug

### DIFF
--- a/src/app/common/hooks/use-media-query.ts
+++ b/src/app/common/hooks/use-media-query.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { BreakpointToken, token } from 'leather-styles/tokens';
 
 function useMediaQuery(query: string) {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
 
   useEffect(() => {
     const media = window.matchMedia(query);

--- a/src/app/features/dialogs/switch-account-dialog/switch-account-dialog.tsx
+++ b/src/app/features/dialogs/switch-account-dialog/switch-account-dialog.tsx
@@ -76,7 +76,7 @@ export const SwitchAccountDialog = memo(({ isShowing, onClose }: SwitchAccountDi
           initialTopMostItemIndex={whenWallet({ ledger: 0, software: currentAccountIndex })}
           totalCount={accountNum}
           itemContent={index => (
-            <Box key={index} my="space.05" px="space.05">
+            <Box key={index} py="space.03" px="space.05">
               <SwitchAccountListItem
                 handleClose={onClose}
                 currentAccountIndex={currentAccountIndex}

--- a/src/app/ui/components/virtuoso.tsx
+++ b/src/app/ui/components/virtuoso.tsx
@@ -20,7 +20,7 @@ export function VirtuosoWrapper({ children, hasFooter, isPopup }: VirtuosoWrappe
   const [key, setKey] = useState(0);
   const isAtLeastMd = useViewportMinWidth('md');
   const virtualHeight = isAtLeastMd ? '70vh' : '100vh';
-  const headerHeight = isPopup ? 230 : 80;
+  const headerHeight = isPopup ? 230 : 60;
   const footerHeight = hasFooter ? 95 : 0;
   const heightOffset = headerHeight + footerHeight;
   const height = vhToPixels(virtualHeight) - heightOffset;
@@ -33,9 +33,10 @@ export function VirtuosoWrapper({ children, hasFooter, isPopup }: VirtuosoWrappe
   return (
     <Box
       key={key}
+      pt="space.03"
+      overflow="hidden"
       style={{
         height: height,
-        overflow: 'hidden',
         marginBottom: hasFooter ? `${footerHeight}px` : '10px',
       }}
     >


### PR DESCRIPTION
> Try out Leather build 5cbb598 — [Extension build](https://github.com/leather-io/extension/actions/runs/10175990921), [Test report](https://leather-io.github.io/playwright-reports/fix-switch-modal-jump), [Storybook](https://fix-switch-modal-jump--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-switch-modal-jump)<!-- Sticky Header Marker -->

This pr fixes in full mode: 
- switch account modal "jump" on open
- problem of too many accounts rendered on open

https://github.com/user-attachments/assets/ee0ffe16-3c78-4bd1-aed6-614b1d1a1fba

![Screenshot 2024-07-30 at 14 51 23](https://github.com/user-attachments/assets/4cf1e998-f403-4e84-ac35-6a0a4b99860b)
