### PR TITLE
fix: validate dom nesting console error

### DIFF
--- a/src/app/pages/home/components/account-actions.tsx
+++ b/src/app/pages/home/components/account-actions.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ChainID } from '@stacks/transactions';
 import { HomePageSelectors } from '@tests/selectors/home.selectors';
-import { Flex } from 'leather-styles/jsx';
+import { Box, Flex } from 'leather-styles/jsx';
 
 import { whenStacksChainId } from '@leather.io/stacks';
 import { CreditCardIcon, IconButton, InboxIcon, SwapIcon } from '@leather.io/ui';
@@ -56,14 +56,22 @@ export function AccountActions() {
       )}
       {whenStacksChainId(currentNetwork.chain.stacks.chainId)({
         [ChainID.Mainnet]: (
-          <BasicTooltip label={swapsEnabled ? '' : <SwapsDisabledTooltipLabel />} side="left">
-            <IconButton
-              data-testid={HomePageSelectors.SwapBtn}
-              disabled={swapsBtnDisabled}
-              icon={<SwapIcon />}
-              label="Swap"
-              onClick={() => navigate(RouteUrls.Swap.replace(':base', 'STX').replace(':quote', ''))}
-            />
+          <BasicTooltip
+            label={swapsEnabled ? '' : <SwapsDisabledTooltipLabel />}
+            side="left"
+            asChild
+          >
+            <Box>
+              <IconButton
+                data-testid={HomePageSelectors.SwapBtn}
+                disabled={swapsBtnDisabled}
+                icon={<SwapIcon />}
+                label="Swap"
+                onClick={() =>
+                  navigate(RouteUrls.Swap.replace(':base', 'STX').replace(':quote', ''))
+                }
+              />
+            </Box>
           </BasicTooltip>
         ),
         [ChainID.Testnet]: null,


### PR DESCRIPTION
> Try out Leather build c3468a0 — [Extension build](https://github.com/leather-io/extension/actions/runs/10458440032), [Test report](https://leather-io.github.io/playwright-reports/fix-validate-nesting), [Storybook](https://fix-validate-nesting--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-validate-nesting)<!-- Sticky Header Marker -->

Fix annoying `validateDomNesting` error in console
![Screenshot 2024-08-19 at 21 52 02](https://github.com/user-attachments/assets/c5093465-f294-450b-ad75-40812eac368f)
