### PR TITLE
feat: change gaia related requests priority levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@leather.io/constants": "0.12.5",
     "@leather.io/crypto": "1.6.6",
     "@leather.io/models": "0.18.2",
-    "@leather.io/query": "2.15.2",
+    "@leather.io/query": "2.16.0",
     "@leather.io/stacks": "1.2.3",
     "@leather.io/tokens": "0.9.1",
     "@leather.io/ui": "1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 0.18.2
         version: 0.18.2
       '@leather.io/query':
-        specifier: 2.15.2
-        version: 2.15.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
+        specifier: 2.16.0
+        version: 2.16.0(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
       '@leather.io/stacks':
         specifier: 1.2.3
         version: 1.2.3(encoding@0.1.13)
@@ -3075,8 +3075,8 @@ packages:
   '@leather.io/prettier-config@0.6.0':
     resolution: {integrity: sha512-QBKtLanfxFxXBlR58U/j8a6lBI0xzJzqqi36fXpGVp+9mJoEf6Ro6xrtFrixjW6seY6EOva4OApVnnPBsvOC/w==}
 
-  '@leather.io/query@2.15.2':
-    resolution: {integrity: sha512-vri5lSWxqeMA4l14att9PIT0PH7BxWtykRCAuJS9AdYbxIKkT08ER1Sr+4IjcsKQvSStLmhzQD/LSR1By/etTA==}
+  '@leather.io/query@2.16.0':
+    resolution: {integrity: sha512-SvWSJTDdNxx+CpCtQIAScJsA0Wu2SpGJsUjGDKKzbHCGpmfW3ZD4Hdc5Pl8B7CFU6v5RwQgCHamv0HpKxFeD6Q==}
     peerDependencies:
       react: '*'
 
@@ -18725,7 +18725,7 @@ snapshots:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/query@2.15.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
+  '@leather.io/query@2.16.0(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
     dependencies:
       '@fungible-systems/zone-file': 2.0.0
       '@hirosystems/token-metadata-api-client': 1.2.0(encoding@0.1.13)

--- a/src/app/common/authentication/use-finish-auth-request.ts
+++ b/src/app/common/authentication/use-finish-auth-request.ts
@@ -8,7 +8,7 @@ import {
 } from '@stacks/wallet-sdk';
 
 import { gaiaUrl } from '@leather.io/constants';
-import { useHiroApiRateLimiter } from '@leather.io/query';
+import { hiroApiRequestsPriorityLevels, useHiroApiRateLimiter } from '@leather.io/query';
 
 import { finalizeAuthResponse } from '@shared/actions/finalize-auth-response';
 import { logger } from '@shared/logger';
@@ -60,7 +60,7 @@ export function useFinishAuthRequest() {
           const gaiaHubConfig = await hiroLimiter.add(
             () => createWalletGaiaConfig({ gaiaHubUrl: gaiaUrl, wallet }),
             {
-              priority: 5,
+              priority: hiroApiRequestsPriorityLevels.createWalletGaiaConfig,
               throwOnTimeout: true,
             }
           );
@@ -99,7 +99,7 @@ export function useFinishAuthRequest() {
                 },
               });
             },
-            { priority: 5, throwOnTimeout: true }
+            { priority: hiroApiRequestsPriorityLevels.makeAuthResponse, throwOnTimeout: true }
           );
 
           keyActions.switchAccount(accountIndex);


### PR DESCRIPTION
> Try out Leather build 9380afc — [Extension build](https://github.com/leather-io/extension/actions/runs/11508714219), [Test report](https://leather-io.github.io/playwright-reports/feat-change-gaia-request-priority), [Storybook](https://feat-change-gaia-request-priority--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-change-gaia-request-priority)<!-- Sticky Header Marker -->

This pr adds proper priority levels for gaia related requests, so they are made before any other ones in hiro request queue