### PR TITLE
feat: remove stacks tx estimated time, LEA-1686

### DIFF
--- a/src/app/common/transactions/stacks/transaction.utils.ts
+++ b/src/app/common/transactions/stacks/transaction.utils.ts
@@ -2,7 +2,6 @@ import { bytesToHex } from '@stacks/common';
 import { TransactionTypes } from '@stacks/connect';
 import {
   CoinbaseTransaction,
-  NetworkBlockTimesResponse,
   TransactionEventFungibleAsset,
 } from '@stacks/stacks-blockchain-api-types';
 import {
@@ -125,19 +124,6 @@ export function getTxSenderAddress(tx: StacksTransaction): string | undefined {
     tx.version
   );
   return txSender;
-}
-
-export function getEstimatedConfirmationTime(
-  isTestnet: boolean,
-  blockTime?: NetworkBlockTimesResponse
-) {
-  const arrivesIn = isTestnet
-    ? blockTime?.testnet.target_block_time
-    : blockTime?.mainnet.target_block_time;
-
-  if (!arrivesIn) return '~10 – 20 min';
-
-  return `~${arrivesIn / 60} min`;
 }
 
 export function isPendingTx(tx: StacksTx) {

--- a/src/app/features/stacks-transaction-request/hooks/use-stacks-transaction-summary.ts
+++ b/src/app/features/stacks-transaction-request/hooks/use-stacks-transaction-summary.ts
@@ -12,10 +12,7 @@ import {
 import BigNumber from 'bignumber.js';
 
 import type { CryptoCurrency } from '@leather.io/models';
-import {
-  useCryptoCurrencyMarketDataMeanAverage,
-  useGetStacksNetworkBlockTimeQuery,
-} from '@leather.io/query';
+import { useCryptoCurrencyMarketDataMeanAverage } from '@leather.io/query';
 import {
   baseCurrencyAmountInQuote,
   convertToMoneyTypeWithDefaultOfZero,
@@ -26,15 +23,11 @@ import {
   microStxToStx,
 } from '@leather.io/utils';
 
-import { getEstimatedConfirmationTime } from '@app/common/transactions/stacks/transaction.utils';
 import { removeTrailingNullCharacters } from '@app/common/utils';
-import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 export function useStacksTransactionSummary(token: CryptoCurrency) {
   // TODO: unsafe type assumption
   const tokenMarketData = useCryptoCurrencyMarketDataMeanAverage(token as 'BTC' | 'STX');
-  const { isTestnet } = useCurrentNetworkState();
-  const { data: blockTime } = useGetStacksNetworkBlockTimeQuery();
 
   function formSentSummaryTxState(txId: string, signedTx: StacksTransaction, decimals?: number) {
     return {
@@ -64,7 +57,6 @@ export function useStacksTransactionSummary(token: CryptoCurrency) {
       recipient: addressToString(payload.recipient.address),
       fee: formatMoney(convertToMoneyTypeWithDefaultOfZero('STX', Number(fee))),
       totalSpend: formatMoney(convertToMoneyTypeWithDefaultOfZero('STX', Number(txValue + fee))),
-      arrivesIn: getEstimatedConfirmationTime(isTestnet, blockTime),
       symbol: 'STX',
       txValue: microStxToStx(Number(txValue)).toString(),
       sendingValue: formatMoney(convertToMoneyTypeWithDefaultOfZero('STX', Number(txValue))),
@@ -109,7 +101,6 @@ export function useStacksTransactionSummary(token: CryptoCurrency) {
 
     return {
       recipient: cvToString(payload.functionArgs[2]),
-      arrivesIn: getEstimatedConfirmationTime(isTestnet, blockTime),
       txValue: new BigNumber(txValue).shiftedBy(-decimals).toString(),
       nonce: String(tx.auth.spendingCondition.nonce),
       fee: feeValue,

--- a/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.tsx
@@ -15,7 +15,6 @@ interface SendFormConfirmationProps {
   recipient: string;
   fee?: string;
   totalSpend: string;
-  arrivesIn: string;
   symbol: string;
   txValue: string | number;
   sendingValue: string;
@@ -35,7 +34,6 @@ export function SendFormConfirmation({
   fee,
   totalSpend,
   sendingValue,
-  arrivesIn,
   isLoading,
   onBroadcastTransaction,
   nonce,
@@ -96,7 +94,6 @@ export function SendFormConfirmation({
           data-testid={SendCryptoAssetSelectors.ConfirmationDetailsMemo}
         />
         <InfoCardRow title="Nonce" value={nonce} />
-        <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />
       </Stack>
     </Card>
   );

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
@@ -46,7 +46,6 @@ export function StacksSendFormConfirmation() {
     fee,
     totalSpend,
     sendingValue,
-    arrivesIn,
     nonce,
     memoDisplayText,
   } = formReviewTxSummary(stacksDeserializedTransaction, symbol, decimals);
@@ -80,7 +79,6 @@ export function StacksSendFormConfirmation() {
             fee={fee}
             totalSpend={totalSpend}
             sendingValue={sendingValue}
-            arrivesIn={arrivesIn}
             nonce={nonce}
             memoDisplayText={memoDisplayText}
             symbol={symbol.toUpperCase()}

--- a/src/app/pages/send/sent-summary/stx-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/stx-sent-summary.tsx
@@ -28,7 +28,6 @@ export function StxSentSummary() {
     txFiatValueSymbol,
     symbol,
     txLink,
-    arrivesIn,
     fee,
     recipient,
     txId,
@@ -77,7 +76,6 @@ export function StxSentSummary() {
 
               <InfoCardRow title="Sending" value={sendingValue} />
               <InfoCardRow title="Fee" value={fee} />
-              <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />
             </Stack>
           </Card>
         </Page>

--- a/src/app/pages/swap/components/swap-details/swap-details.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-details.tsx
@@ -2,7 +2,6 @@ import { SwapSelectors } from '@tests/selectors/swap.selectors';
 import BigNumber from 'bignumber.js';
 import { HStack, styled } from 'leather-styles/jsx';
 
-import { useGetStacksNetworkBlockTimeQuery } from '@leather.io/query';
 import { ChevronRightIcon } from '@leather.io/ui';
 import {
   createMoneyFromDecimal,
@@ -12,9 +11,7 @@ import {
   microStxToStx,
 } from '@leather.io/utils';
 
-import { getEstimatedConfirmationTime } from '@app/common/transactions/stacks/transaction.utils';
 import { SwapSubmissionData, useSwapContext } from '@app/pages/swap/swap.context';
-import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 import { toCommaSeparatedWithAnd } from '../../swap.utils';
 import { SwapDetailLayout } from './swap-detail.layout';
@@ -37,8 +34,6 @@ const sponsoredFeeLabel =
 
 export function SwapDetails() {
   const { swapSubmissionData } = useSwapContext();
-  const { isTestnet } = useCurrentNetworkState();
-  const { data: blockTime } = useGetStacksNetworkBlockTimeQuery();
 
   if (
     isUndefined(swapSubmissionData) ||
@@ -96,10 +91,6 @@ export function SwapDetails() {
             ? 'Sponsored'
             : `${microStxToStx(swapSubmissionData.fee).toString()} STX`
         }
-      />
-      <SwapDetailLayout
-        title="Estimated confirmation time"
-        value={getEstimatedConfirmationTime(isTestnet, blockTime)}
       />
       <SwapDetailLayout title="Nonce" value={swapSubmissionData.nonce?.toString() ?? 'Unknown'} />
     </SwapDetailsLayout>


### PR DESCRIPTION
> Try out Leather build 31a024d — [Extension build](https://github.com/leather-io/extension/actions/runs/11593983049), [Test report](https://leather-io.github.io/playwright-reports/feat-remove-estimated), [Storybook](https://feat-remove-estimated--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-remove-estimated)<!-- Sticky Header Marker -->

This pr removes estimated time data in stacks transaction flow