### PR TITLE
feat: add options to btc tx item

### DIFF
--- a/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item-menu.tsx
+++ b/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item-menu.tsx
@@ -1,19 +1,15 @@
 import { ActivitySelectors } from '@tests/selectors/activity.selectors';
 import { HStack, styled } from 'leather-styles/jsx';
 
-import { ChevronsRightIcon, CloseIcon, DropdownMenu } from '@leather.io/ui';
+import { ChevronsRightIcon, DropdownMenu } from '@leather.io/ui';
 
 import { TransactionActionMenu } from '../transaction-item/transaction-action-menu';
 
-interface StacksTransactionActionMenuProps {
+interface BitcoinTransactionActionMenuProps {
   onIncreaseFee(): void;
-  onCancelTransaction(): void;
 }
 
-export function StacksTransactionActionMenu({
-  onIncreaseFee,
-  onCancelTransaction,
-}: StacksTransactionActionMenuProps) {
+export function BitcoinTransactionActionMenu({ onIncreaseFee }: BitcoinTransactionActionMenuProps) {
   return (
     <TransactionActionMenu>
       <DropdownMenu.Item
@@ -26,18 +22,6 @@ export function StacksTransactionActionMenu({
         <HStack>
           <ChevronsRightIcon variant="small" />
           <styled.span textStyle="label.02">Increase fee</styled.span>
-        </HStack>
-      </DropdownMenu.Item>
-      <DropdownMenu.Item
-        data-testid={ActivitySelectors.ActivityItemMenuCancelTransaction}
-        onClick={e => {
-          e.stopPropagation();
-          onCancelTransaction();
-        }}
-      >
-        <HStack>
-          <CloseIcon variant="small" />
-          <styled.span textStyle="label.02">Cancel transaction</styled.span>
         </HStack>
       </DropdownMenu.Item>
     </TransactionActionMenu>

--- a/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
+++ b/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
@@ -18,7 +18,6 @@ import {
   isBitcoinTxInbound,
 } from '@app/common/transactions/bitcoin/utils';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
-import { IncreaseFeeButton } from '@app/components/stacks-transaction-item/increase-fee-button';
 import { TransactionTitle } from '@app/components/transaction/transaction-title';
 import { useCurrentAccountNativeSegwitAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
@@ -26,6 +25,7 @@ import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
 import { TransactionItemLayout } from '../transaction-item/transaction-item.layout';
 import { BitcoinTransactionIcon } from './bitcoin-transaction-icon';
 import { InscriptionIcon } from './bitcoin-transaction-inscription-icon';
+import { BitcoinTransactionActionMenu } from './bitcoin-transaction-item-menu';
 import { BitcoinTransactionStatus } from './bitcoin-transaction-status';
 
 interface BitcoinTransactionItemProps {
@@ -75,18 +75,17 @@ export function BitcoinTransactionItem({ transaction }: BitcoinTransactionItemPr
   );
 
   const title = inscriptionData ? `Ordinal inscription #${inscriptionData.number}` : 'Bitcoin';
-  const increaseFeeButton = (
-    <IncreaseFeeButton
-      isEnabled={isEnabled}
-      isSelected={pathname === RouteUrls.IncreaseBtcFee}
-      onIncreaseFee={onIncreaseFee}
-    />
-  );
+
+  const isSelected = pathname === RouteUrls.IncreaseBtcFee;
+  const rightElement =
+    isEnabled && !isSelected ? (
+      <BitcoinTransactionActionMenu onIncreaseFee={onIncreaseFee} />
+    ) : undefined;
 
   return (
     <TransactionItemLayout
       openTxLink={openTxLink}
-      rightElement={isEnabled ? increaseFeeButton : undefined}
+      rightElement={rightElement}
       txCaption={txCaption}
       txIcon={
         <BitcoinTransactionIcon

--- a/src/app/components/transaction-item/transaction-action-menu.tsx
+++ b/src/app/components/transaction-item/transaction-action-menu.tsx
@@ -1,0 +1,44 @@
+import { ActivitySelectors } from '@tests/selectors/activity.selectors';
+import { css } from 'leather-styles/css';
+import { styled } from 'leather-styles/jsx';
+
+import { ChevronDownIcon, DropdownMenu, Flag } from '@leather.io/ui';
+
+interface TransactionActionMenuProps {
+  children: React.ReactNode;
+}
+
+export function TransactionActionMenu({ children }: TransactionActionMenuProps) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        data-testid={ActivitySelectors.ActivityItemMenuBtn}
+        className={css({
+          zIndex: 10,
+          borderRadius: 'sm',
+          px: 'space.01',
+          _hover: {
+            background: 'ink.component-background-hover',
+          },
+        })}
+      >
+        <Flag spacing="space.02" reverse img={<ChevronDownIcon variant="small" />}>
+          <styled.span textStyle="label.03">Options</styled.span>
+        </Flag>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          side="bottom"
+          sideOffset={8}
+          className={css({
+            zIndex: 100,
+            width: 'settingsMenuWidth',
+          })}
+        >
+          <DropdownMenu.Group>{children}</DropdownMenu.Group>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}


### PR DESCRIPTION
> Try out Leather build adc6302 — [Extension build](https://github.com/leather-io/extension/actions/runs/11595697374), [Test report](https://leather-io.github.io/playwright-reports/feat-btc-options), [Storybook](https://feat-btc-options--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-btc-options)<!-- Sticky Header Marker -->

this pr adds options menu to btc tx item
![Screenshot 2024-10-30 at 18 42 30](https://github.com/user-attachments/assets/d6736a30-f64c-4db2-8d5c-73e8652d479e)
