### PR TITLE
fix: codeblock colors

### DIFF
--- a/src/app/ui/components/codeblock.tsx
+++ b/src/app/ui/components/codeblock.tsx
@@ -12,7 +12,7 @@ export const CodeBlock = forwardRef(
     ref: React.Ref<HTMLDivElement>
   ) => (
     <Box
-      bg="invert"
+      bg="ink.background-primary"
       borderRadius={[0, 'lg']}
       overflowX="auto"
       p="space.04"

--- a/src/app/ui/components/highlighter.tsx
+++ b/src/app/ui/components/highlighter.tsx
@@ -88,7 +88,7 @@ function Line({
         hideLineHover
           ? undefined
           : {
-              bg: ['unset', 'unset', 'ink.text-primary'],
+              bg: ['unset', 'unset', 'ink.background-secondary'],
               borderColor: ['ink.text-primary', 'ink.text-primary', 'ink.text-subdued'],
             }
       }

--- a/src/app/ui/utils/prism.tsx
+++ b/src/app/ui/utils/prism.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties } from 'react';
 
+import { token } from 'leather-styles/tokens';
 import { PrismTheme } from 'prism-react-renderer';
 
 export interface GrammaticalToken {
@@ -89,74 +90,43 @@ export type Language =
 
 export const theme: PrismTheme = {
   plain: {
-    color: 'unset',
-    background: 'transparent',
+    color: token('colors.ink.text-primary'),
   },
   styles: [
     {
-      types: ['prolog'],
-      style: {
-        color: 'rgb(0, 0, 128)',
-      },
-    },
-    {
       types: ['comment', 'punctuation'],
       style: {
-        color: 'rgb(106, 153, 85)',
-      },
-    },
-    {
-      types: ['builtin', 'tag', 'changed', 'function', 'keyword'],
-      style: {
-        color: 'rgb(86, 156, 214)',
-      },
-    },
-    {
-      types: ['number', 'variable', 'inserted'],
-      style: {
-        color: '#A58FFF',
+        color: token('colors.ink.text-subdued'),
       },
     },
     {
       types: ['operator'],
       style: {
-        color: 'rgb(212, 212, 212)',
+        color: token('colors.ink.text-primary'),
       },
     },
     {
-      types: ['constant'],
+      types: ['builtin', 'tag', 'changed', 'keyword'],
       style: {
-        color: 'rgb(100, 102, 149)',
+        color: token('colors.yellow.action-primary-default'),
       },
     },
     {
-      types: ['attr-name'],
+      types: ['function'],
       style: {
-        color: 'rgb(156, 220, 254)',
+        color: token('colors.red.action-primary-default'),
       },
     },
     {
-      types: ['car'],
+      types: ['number', 'variable', 'inserted'],
       style: {
-        color: 'rgb(156, 220, 254)',
+        color: token('colors.yellow.action-primary-default'),
       },
     },
     {
-      types: ['deleted', 'string'],
+      types: ['deleted', 'string', 'symbol', 'char'],
       style: {
-        color: '#FF7B48',
-      },
-    },
-    {
-      types: ['class-name'],
-      style: {
-        color: 'rgb(78, 201, 176)',
-      },
-    },
-    {
-      types: ['char'],
-      style: {
-        color: '#FF7B48',
+        color: token('colors.green.action-primary-default'),
       },
     },
   ],


### PR DESCRIPTION
> Try out Leather build f9f55d2 — [Extension build](https://github.com/leather-io/extension/actions/runs/11724438334), [Test report](https://leather-io.github.io/playwright-reports/fix-codeblock-colors), [Storybook](https://fix-codeblock-colors--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-codeblock-colors)<!-- Sticky Header Marker -->

Before:

<img width="663" alt="beforeLight" src="https://github.com/user-attachments/assets/cc8d7001-903f-4ee0-81e2-88977e9afae7">
<img width="694" alt="beforeDark" src="https://github.com/user-attachments/assets/0cfbaf94-bbc6-4783-8a3d-e041b5a46dc0">



After:

<img width="691" alt="dark" src="https://github.com/user-attachments/assets/7269bd40-6baa-4ccc-8628-3998467f14f0">
<img width="683" alt="light" src="https://github.com/user-attachments/assets/91602a7a-32a1-4ac1-836d-c5f735d209bb">
