### PR TITLE
fix: bns name overflow issue

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/components/recipient-address-displayer.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/components/recipient-address-displayer.tsx
@@ -1,46 +1,44 @@
-import { useCallback } from 'react';
-
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
-import { HStack, styled } from 'leather-styles/jsx';
+import { motion } from 'framer-motion';
+import { HStack } from 'leather-styles/jsx';
 
-import { CopyIcon } from '@leather.io/ui';
+import { AddressDisplayer, CopyIcon } from '@leather.io/ui';
 
 import { analytics } from '@shared/utils/analytics';
 
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+import { useToast } from '@app/features/toasts/use-toast';
 
 interface RecipientAddressDisplayerProps {
   address: string;
 }
 export function RecipientAddressDisplayer({ address }: RecipientAddressDisplayerProps) {
-  const { onCopy, hasCopied } = useClipboard(address);
+  const { onCopy } = useClipboard(address);
+  const toast = useToast();
 
-  const copyToClipboard = useCallback(() => {
+  function copyToClipboard() {
+    toast.success('Copied to clipboard!');
+
     void analytics.track('copy_recipient_bns_address_to_clipboard');
     onCopy();
-  }, [onCopy]);
+  }
 
   return (
-    <HStack mb="space.04" width="100%" px="space.04" mt="space.02">
-      <styled.span
-        textStyle="caption.01"
-        data-testid={SendCryptoAssetSelectors.RecipientBnsAddressLabel}
-      >
-        {address}
-      </styled.span>
-      {/** TODO: We need to persist the tooltip after it is clicked.
-           Current implementation of radix-ui tooltip doesn't allow that, ref: https://github.com/radix-ui/primitives/issues/2029 */}
-      <BasicTooltip label={hasCopied ? 'Copied!' : 'Copy address'} side="right" asChild>
-        <styled.button
-          _hover={{ cursor: 'pointer' }}
-          data-testid={SendCryptoAssetSelectors.RecipientBnsAddressCopyToClipboard}
-          onClick={copyToClipboard}
+    <HStack mb="space.04" width="100%" mt="space.02">
+      <HStack onClick={copyToClipboard} cursor="pointer">
+        <AddressDisplayer
+          data-testid={SendCryptoAssetSelectors.RecipientBnsAddressLabel}
+          address={address}
+        />
+
+        <motion.button
           type="button"
+          whileTap={{ scale: 0.85 }}
+          data-testid={SendCryptoAssetSelectors.RecipientBnsAddressCopyToClipboard}
         >
           <CopyIcon />
-        </styled.button>
-      </BasicTooltip>
+        </motion.button>
+      </HStack>
     </HStack>
   );
 }


### PR DESCRIPTION
> Try out Leather build 5e01143 — [Extension build](https://github.com/leather-io/extension/actions/runs/11796680194), [Test report](https://leather-io.github.io/playwright-reports/fix-bns-width), [Storybook](https://fix-bns-width--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-bns-width)<!-- Sticky Header Marker -->

This pr fixes bns name overflow issue
was:
![Screenshot 2024-11-12 at 15 49 10](https://github.com/user-attachments/assets/b87159dd-db16-4ff2-b96a-854b2d1d239a)

now:
![Screenshot 2024-11-12 at 15 48 17](https://github.com/user-attachments/assets/d362c5ab-1d61-429a-9e01-a453c529b91b)
