### PR TITLE
fix: go back from btc and stx choose fee step

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -70,7 +70,6 @@ export function BtcSendForm() {
                         <Button
                           aria-busy={props.isValidating}
                           data-testid={SendCryptoAssetSelectors.PreviewSendTxBtn}
-                          onClick={() => props.handleSubmit()}
                           type="submit"
                         >
                           Continue

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
@@ -71,7 +71,6 @@ export function StacksCommonSendForm({
                       <Button
                         aria-busy={props.isValidating}
                         data-testid={SendCryptoAssetSelectors.PreviewSendTxBtn}
-                        onClick={() => props.handleSubmit()}
                         type="submit"
                         fullWidth
                       >

--- a/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
+++ b/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
@@ -36,16 +36,12 @@ export function useSendFormNavigate() {
 
   return useMemo(
     () => ({
-      backToSendForm(state: any) {
-        return navigate('../', { relative: 'path', replace: true, state });
-      },
       toChooseTransactionFee(
         isSendingMax: boolean,
         utxos: UtxoResponseItem[],
         values: BitcoinSendFormValues
       ) {
         return navigate(RouteUrls.SendBtcChooseFee, {
-          replace: true,
           state: {
             isSendingMax,
             utxos,
@@ -72,7 +68,6 @@ export function useSendFormNavigate() {
       },
       toConfirmAndSignStxTransaction(tx: StacksTransaction, showFeeChangeWarning: boolean) {
         return navigate(RouteUrls.SendStxConfirmation, {
-          replace: true,
           state: {
             tx: bytesToHex(tx.serialize()),
             showFeeChangeWarning,


### PR DESCRIPTION
> Try out Leather build 1079f1f — [Extension build](https://github.com/leather-io/extension/actions/runs/11799092873), [Test report](https://leather-io.github.io/playwright-reports/fix-go-back), [Storybook](https://fix-go-back--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-go-back)<!-- Sticky Header Marker -->

Fix for super annoying go back bug, when from choose stacks/btc fee step user is sent to choose asset page