### PR TITLE
fix: insufficient funds in send max btc flow

### DIFF
--- a/src/app/common/transactions/bitcoin/fees/calculate-max-bitcoin-spend.ts
+++ b/src/app/common/transactions/bitcoin/fees/calculate-max-bitcoin-spend.ts
@@ -38,6 +38,7 @@ export function calculateMaxBitcoinSpend({
     utxos: filteredUtxos,
     feeRate: currentFeeRate,
     recipients: [{ address, amount: createMoney(0, 'BTC') }],
+    isSendMax: true,
   });
 
   return {

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-dialog/account-list-item.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-dialog/account-list-item.tsx
@@ -19,7 +19,7 @@ interface AccountListItemProps {
   onClose(): void;
 }
 export const AccountListItem = memo(({ index, stacksAccount, onClose }: AccountListItemProps) => {
-  const { setFieldValue, values, setFieldTouched } = useFormikContext<
+  const { setFieldValue, values } = useFormikContext<
     BitcoinSendFormValues | StacksSendFormValues
   >();
   const stacksAddress = stacksAccount?.address || '';
@@ -30,7 +30,6 @@ export const AccountListItem = memo(({ index, stacksAccount, onClose }: AccountL
   const onSelectAccount = () => {
     const isBitcoin = values.symbol === 'BTC';
     void setFieldValue('recipient', isBitcoin ? bitcoinAddress : stacksAddress, false);
-    void setFieldTouched('recipient', false);
     onClose();
   };
 


### PR DESCRIPTION
> Try out Leather build b4b494a — [Extension build](https://github.com/leather-io/extension/actions/runs/11949578260), [Test report](https://leather-io.github.io/playwright-reports/fix-bitcoin-send-max-bug), [Storybook](https://fix-bitcoin-send-max-bug--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-bitcoin-send-max-bug)<!-- Sticky Header Marker -->

This pr fixes btc send max funds validation bug
[context](https://trustmachines.slack.com/archives/C05LAP952E7/p1732015122254719)