### PR TITLE
feat: add mock alex prices

### DIFF
--- a/tests/mocks/mock-alex-assets.ts
+++ b/tests/mocks/mock-alex-assets.ts
@@ -40,10 +40,27 @@ const mockedAlexPools = [
   },
 ];
 
-export async function mockMainnetTestAccountAlexAssetsRequest(page: Page) {
+const mockedAlexTokenPrices = [
+  {
+    contract_id: 'SP265WBWD4NH7TVPYQTVD23X3607NNK4484DTXQZ3.longcoin',
+    last_price_usd: 4.23105713004e-7,
+  },
+  {
+    contract_id: 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope',
+    last_price_usd: 0.000046211724535772,
+  },
+];
+
+export async function mockMainnetAlexAssetsRequest(page: Page) {
   await page.route('https://alex-sdk-api.alexlab.co/', route =>
     route.fulfill({
       json: { pools: mockedAlexPools, tokens: mockedAlexTokens },
     })
+  );
+}
+
+export async function mockMainnetAlexTokenPricesRequest(page: Page) {
+  await page.route('https://api.alexgo.io/v2/public/token-prices', route =>
+    route.fulfill({ json: { data: mockedAlexTokenPrices } })
   );
 }

--- a/tests/mocks/mock-apis.ts
+++ b/tests/mocks/mock-apis.ts
@@ -1,7 +1,10 @@
 import { Page } from '@playwright/test';
 import { json } from '@tests/utils';
 
-import { mockMainnetTestAccountAlexAssetsRequest } from './mock-alex-assets';
+import {
+  mockMainnetAlexAssetsRequest,
+  mockMainnetAlexTokenPricesRequest,
+} from './mock-alex-assets';
 import { mockMainnetTestAccountBrc20TokensRequest } from './mock-brc20';
 import { mockMainnetTestAccountRunesOutputsRequest } from './mock-runes';
 import { mockMainnetTestAccountStampchainRequest } from './mock-src20';
@@ -27,7 +30,8 @@ export async function setupMockApis(page: Page) {
     mockMainnetTestAccountStacksNFTsRequest(page),
     mockMainnetTestAccountStacksFTsRequest(page),
     mockMainnetTestAccountStacksBalancesRequest(page),
-    mockMainnetTestAccountAlexAssetsRequest(page),
+    mockMainnetAlexAssetsRequest(page),
+    mockMainnetAlexTokenPricesRequest(page),
 
     mockMainnetTestAccountStampchainRequest(page),
     mockMainnetTestAccountBrc20TokensRequest(page),

--- a/tests/specs/manage-tokens/manage-tokens.spec.ts
+++ b/tests/specs/manage-tokens/manage-tokens.spec.ts
@@ -7,7 +7,6 @@ test.describe('Manage tokens', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
-    await globalPage.page.waitForLoadState('networkidle');
   });
 
   test('that supported sip10 token is shown', async ({ homePage }) => {


### PR DESCRIPTION
> Try out Leather build 7febf28 — [Extension build](https://github.com/leather-io/extension/actions/runs/11959953608), [Test report](https://leather-io.github.io/playwright-reports/feat-mock-alex-prices), [Storybook](https://feat-mock-alex-prices--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-mock-alex-prices)<!-- Sticky Header Marker -->

This pr adds mocking of alex prices and removing waiting for network idle in manage tokens test 