### PR TITLE
fix: last acc hidden in switch acc list, closes #5975

### DIFF
--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -85,7 +85,7 @@ function AddAccountAction() {
     <Box mx="space.05" py="space.02" onClick={onCreateAccount} {...bind}>
       <HStack alignItems="center">
         <PlusIcon />
-        Generate new account
+        <styled.span textStyle="label.02">Generate new account</styled.span>
       </HStack>
       {component}
     </Box>

--- a/src/app/ui/components/virtuoso.tsx
+++ b/src/app/ui/components/virtuoso.tsx
@@ -20,7 +20,7 @@ export function VirtuosoWrapper({ children, hasFooter, isPopup }: VirtuosoWrappe
   const [key, setKey] = useState(0);
   const isAtLeastMd = useViewportMinWidth('md');
   const virtualHeight = isAtLeastMd ? '70vh' : '100vh';
-  const headerHeight = isPopup ? 230 : 60;
+  const headerHeight = isPopup ? 300 : 80;
   const footerHeight = hasFooter ? 95 : 0;
   const heightOffset = headerHeight + footerHeight;
   const height = vhToPixels(virtualHeight) - heightOffset;
@@ -33,10 +33,9 @@ export function VirtuosoWrapper({ children, hasFooter, isPopup }: VirtuosoWrappe
   return (
     <Box
       key={key}
-      pt="space.03"
       overflow="hidden"
       style={{
-        height: height,
+        height,
         marginBottom: hasFooter ? `${footerHeight}px` : '10px',
       }}
     >


### PR DESCRIPTION
> Try out Leather build 2945c8d — [Extension build](https://github.com/leather-io/extension/actions/runs/11973580745), [Test report](https://leather-io.github.io/playwright-reports/fix-switch-mb), [Storybook](https://fix-switch-mb--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-switch-mb)<!-- Sticky Header Marker -->

This pr fixes last acc hidden in switch acc sheet and in choose acc flow  