### PR TITLE
fix: endless loading in ledger mode

### DIFF
--- a/src/app/common/hooks/balance/use-total-balance.tsx
+++ b/src/app/common/hooks/balance/use-total-balance.tsx
@@ -47,7 +47,9 @@ export function useTotalBalance({ btcAddress, stxAddress }: UseTotalBalanceArgs)
     return {
       isFetching: isFetchingStxBalance || isFetchingBtcBalance,
       isLoading: isLoadingStxBalance || isLoadingBtcBalance,
-      isPending: isPendingStxBalance || isPendingBtcBalance,
+      isPending:
+        (isPendingStxBalance && Boolean(stxAddress)) ||
+        (isPendingBtcBalance && Boolean(btcAddress)),
       totalBalance,
       totalUsdBalance: i18nFormatCurrency(
         totalBalance,
@@ -69,5 +71,7 @@ export function useTotalBalance({ btcAddress, stxAddress }: UseTotalBalanceArgs)
     stxMarketData,
     isLoadingAdditionalDataBtcBalance,
     isLoadingAdditionalDataStxBalance,
+    stxAddress,
+    btcAddress,
   ]);
 }

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -69,7 +69,7 @@ export function AccountCard({
       </Flex>
       <Flex flexDir={{ base: 'column', md: 'row' }} justify="space-between">
         <Box mb="space.05" mt="space.04">
-          <SkeletonLoader width="200px" height="38px" isLoading={isLoadingBalance}>
+          <SkeletonLoader width="200px" height="46px" isLoading={isLoadingBalance}>
             <styled.h1
               textStyle="heading.02"
               data-state={isLoadingAdditionalData ? 'loading' : undefined}


### PR DESCRIPTION
> Try out Leather build e8f92cd — [Extension build](https://github.com/leather-io/extension/actions/runs/12372536396), [Test report](https://leather-io.github.io/playwright-reports/fix/endless-loading), [Storybook](https://fix/endless-loading--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/endless-loading)<!-- Sticky Header Marker -->

e.g when in btc only ledger mode, there is no stacks address, so stx balance request is always in `pending` status, so we show skeleton loader instead of total balance

will write test in sep pr
![Screenshot 2024-12-17 at 15 49 07](https://github.com/user-attachments/assets/742fd366-8ab6-4c67-b60c-cbbc1512dc2f)

