### PR TITLE
fix: available balance tooltip

### DIFF
--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -13,6 +13,7 @@ import {
   shimmerStyles,
 } from '@leather.io/ui';
 
+import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
 import { useScaleText } from '@app/common/hooks/use-scale-text';
 import { AccountNameLayout } from '@app/components/account/account-name';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
@@ -45,6 +46,8 @@ export function AccountCard({
   isBalancePrivate,
 }: AccountCardProps) {
   const scaleTextRef = useScaleText();
+  const isAtLeastMd = useViewportMinWidth('md');
+  const tooltipSide = isAtLeastMd ? 'right' : 'bottom';
 
   return (
     <Flex
@@ -107,7 +110,7 @@ export function AccountCard({
               Available balance:
               <styled.span ml="space.01">
                 <BasicTooltip
-                  side="right"
+                  side={tooltipSide}
                   label="Some funds may be unavailable to protect your collectible assets. Disable protection to access your remaining balance."
                 >
                   <Flag


### PR DESCRIPTION
> Try out Leather build b32caa4 — [Extension build](https://github.com/leather-io/extension/actions/runs/12492999492), [Test report](https://leather-io.github.io/playwright-reports/fix/available-balance-tooltip), [Storybook](https://fix/available-balance-tooltip--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/available-balance-tooltip)<!-- Sticky Header Marker -->

was:

![image_720](https://github.com/user-attachments/assets/da5928f6-9f2f-42cc-93bc-6b06a2b9371e)

now
![Screenshot 2024-12-25 at 16 17 28](https://github.com/user-attachments/assets/06575d91-326c-40e5-9f07-de134d13a7fb)
![Screenshot 2024-12-25 at 16 17 39](https://github.com/user-attachments/assets/2bffbaa5-ea0f-45c7-afe6-1d48ed9f1a83)
