### PR TITLE
fix: minor padding issue with pc

### DIFF
--- a/src/app/components/rpc-transaction-request/post-conditions/post-condition-item.tsx
+++ b/src/app/components/rpc-transaction-request/post-conditions/post-condition-item.tsx
@@ -48,7 +48,7 @@ export function PostConditionItem({
         captionRight={contract}
       />
       {message && (
-        <Box pt="space.03" borderTop="default" borderBottom={!isLast ? 'active' : 'unset'}>
+        <Box py="space.03" borderTop="default" borderBottom={!isLast ? 'active' : 'unset'}>
           <styled.span color="ink.text-subdued" textStyle="caption.01">
             {message}
           </styled.span>


### PR DESCRIPTION
> _Building Leather at commit e2a0939_<!-- Sticky Header Marker -->

Minor UI bug from contract call refactor, I caught this in testing on Zest and fixed for ft post conditions, but missed it in this component. This code should be shared when we update for v2.

![Screenshot 2025-04-07 at 3 22 06 PM](https://github.com/user-attachments/assets/0f3c9fcc-18a9-418d-8c04-307a69f67d68)

![Screenshot 2025-04-07 at 3 22 27 PM](https://github.com/user-attachments/assets/bccf966a-9a56-4e67-b83c-d0bb02881ad2)
