### PR TITLE
refactor: validate send to contract address, closes LEA-2125

### DIFF
--- a/src/app/common/stacks-utils.ts
+++ b/src/app/common/stacks-utils.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@stacks/network';
+import { type ContractIdString, parseContractId } from '@stacks/transactions';
 import BigNumber from 'bignumber.js';
 import { c32addressDecode } from 'c32check';
 
@@ -48,8 +49,15 @@ export function ftUnshiftDecimals(value: number | string | BigNumber, decimals: 
 }
 
 export function validateStacksAddress(stacksAddress: string): boolean {
+  let addressToValidate = stacksAddress;
   try {
-    c32addressDecode(stacksAddress);
+    if (stacksAddress.includes('.')) {
+      const [address, name] = parseContractId(stacksAddress as ContractIdString);
+      const isValidContractName = name.length <= 40;
+      if (!isValidContractName) return false;
+      addressToValidate = address;
+    }
+    c32addressDecode(addressToValidate);
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
> Try out Leather build 7fa2d60 — [Extension build](https://github.com/leather-io/extension/actions/runs/15281368044), [Test report](https://leather-io.github.io/playwright-reports/refactor/validate-send-to-contract-address), [Storybook](https://refactor/validate-send-to-contract-address--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/validate-send-to-contract-address)<!-- Sticky Header Marker -->

This PR adds validation to allow for sending STX to a contract address.