### PR TITLE
fix: runtime event handler err with collectible cards

### DIFF
--- a/src/app/common/hooks/use-hover-with-children.ts
+++ b/src/app/common/hooks/use-hover-with-children.ts
@@ -13,12 +13,12 @@ export function useHoverWithChildren(): [boolean, HoverBind] {
   }, []);
 
   const handleMouseLeave = useCallback((event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    const relatedTarget = event.relatedTarget as HTMLElement;
+    const relatedTarget = event.relatedTarget;
+
+    if (relatedTarget === window) return;
 
     // If the related target is a child of the current element, don't trigger mouseleave
-    if (event.currentTarget.contains(relatedTarget)) {
-      return;
-    }
+    if (event.currentTarget.contains(relatedTarget as Node)) return;
 
     setIsHovered(false);
   }, []);


### PR DESCRIPTION
> Try out Leather build aa8912e — [Extension build](https://github.com/leather-io/extension/actions/runs/15731785712), [Test report](https://leather-io.github.io/playwright-reports/fix/hover-children-err), [Storybook](https://fix/hover-children-err--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/hover-children-err)<!-- Sticky Header Marker -->

Fixes runtime error I came across relating to the hover interaction on home page