### PR TITLE
fix: use a custom component for fee items, closes LEA-3135

### DIFF
--- a/src/app/features/fee-editor/components/custom-fee-item.tsx
+++ b/src/app/features/fee-editor/components/custom-fee-item.tsx
@@ -3,7 +3,9 @@ import { useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Stack } from 'leather-styles/jsx';
 
-import { Button, Input } from '@leather.io/ui';
+import { Input } from '@leather.io/ui';
+
+import { FeeItemButton } from '@app/features/fee-editor/components/fee-item-button';
 
 import { type Fee, useFeeEditorContext } from '../fee-editor.context';
 import { FeeRateItemLayout } from './fee-rate-item.layout';
@@ -20,14 +22,7 @@ export function CustomFeeItem({ fee }: CustomFeeItemProps) {
   const isSelected = selectedFee?.priority === fee.priority;
 
   return (
-    <Button
-      onClick={() => onSetSelectedFee(fee)}
-      variant="outline"
-      borderWidth={isSelected ? '2px' : '1px'}
-      borderColor={isSelected ? 'ink.border-selected' : 'ink.border-default'}
-      // Add margin compensation to maintain consistent size
-      margin={isSelected ? '0px' : '1px'}
-    >
+    <FeeItemButton onClick={() => onSetSelectedFee(fee)} isSelected={isSelected}>
       {feeType === 'fee-rate' ? <FeeRateItemLayout fee={fee} marketData={marketData} /> : null}
       {feeType === 'fee-value' ? <FeeValueItemLayout fee={fee} marketData={marketData} /> : null}
       <AnimatePresence>
@@ -59,6 +54,6 @@ export function CustomFeeItem({ fee }: CustomFeeItemProps) {
           </motion.div>
         )}
       </AnimatePresence>
-    </Button>
+    </FeeItemButton>
   );
 }

--- a/src/app/features/fee-editor/components/fee-item-button.tsx
+++ b/src/app/features/fee-editor/components/fee-item-button.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+
+import { styled } from 'leather-styles/jsx';
+
+interface FeeItemButtonProps {
+  onClick(): void;
+  isSelected?: boolean;
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+export function FeeItemButton({ onClick, isSelected, disabled, children }: FeeItemButtonProps) {
+  return (
+    <styled.button
+      onClick={onClick}
+      p="space.03"
+      borderRadius="sm"
+      opacity={disabled ? 0.5 : 1}
+      borderWidth={isSelected ? '2px' : '1px'}
+      borderColor={isSelected && !disabled ? 'ink.border-selected' : 'ink.border-default'}
+      margin={isSelected ? '0px' : '1px'}
+      disabled={disabled}
+    >
+      {children}
+    </styled.button>
+  );
+}

--- a/src/app/features/fee-editor/components/fee-item.tsx
+++ b/src/app/features/fee-editor/components/fee-item.tsx
@@ -3,11 +3,10 @@ import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Stack } from 'leather-styles/jsx';
 
-import { Button } from '@leather.io/ui';
-
 import { FormError } from '@app/components/form-error';
 
 import { type Fee, useFeeEditorContext } from '../fee-editor.context';
+import { FeeItemButton } from './fee-item-button';
 import { FeeRateItemLayout } from './fee-rate-item.layout';
 import { FeeValueItemLayout } from './fee-value-item.layout';
 
@@ -24,21 +23,13 @@ export function FeeItem({ fee }: FeeItemProps) {
   const showInsufficientBalanceError = isTouched && isInsufficientBalance;
 
   return (
-    <Button
+    <FeeItemButton
       onClick={() => {
         setIsTouched(true);
-        if (isInsufficientBalance) return;
         onSetSelectedFee(fee);
       }}
-      key={fee.priority}
-      variant="outline"
-      opacity={isInsufficientBalance ? 0.5 : 1}
-      borderWidth={isSelected ? '2px' : '1px'}
-      borderColor={
-        isSelected && !isInsufficientBalance ? 'ink.border-selected' : 'ink.border-default'
-      }
-      // Add margin compensation to maintain consistent size
-      margin={isSelected ? '0px' : '1px'}
+      disabled={isInsufficientBalance}
+      isSelected={isSelected}
     >
       <Stack gap="0">
         {feeType === 'fee-rate' ? <FeeRateItemLayout fee={fee} marketData={marketData} /> : null}
@@ -61,6 +52,6 @@ export function FeeItem({ fee }: FeeItemProps) {
           )}
         </AnimatePresence>
       </Stack>
-    </Button>
+    </FeeItemButton>
   );
 }


### PR DESCRIPTION
> Try out Leather build ae8c513 — [Extension build](https://github.com/leather-io/extension/actions/runs/17064532220), [Test report](https://leather-io.github.io/playwright-reports/fix/fee-buttons), [Storybook](https://fix/fee-buttons--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/fee-buttons)<!-- Sticky Header Marker -->

### Before
<img width="502" alt="image" src="https://github.com/user-attachments/assets/a39f8779-1773-4e6b-9586-0f8a5cd16b97" />

### After
<img width="502" alt="image" src="https://github.com/user-attachments/assets/fcc4805d-3d61-4aa2-b3a7-f2da9d8328c7" />