### PR TITLE
feat: more obvious full page button

### DIFF
--- a/src/app/components/full-screen-button.tsx
+++ b/src/app/components/full-screen-button.tsx
@@ -1,0 +1,29 @@
+import { useLocation } from 'react-router';
+
+import { Box } from 'leather-styles/jsx';
+
+import { ExpandIcon } from '@leather.io/ui';
+
+import { analytics } from '@shared/utils/analytics';
+
+import { openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
+
+export function FullScreenButton() {
+  const location = useLocation();
+  return (
+    <Box
+      _hover={{ bg: 'ink.component-background-hover' }}
+      _focus={{ outline: 'none' }}
+      p="space.02"
+      onClick={() => {
+        void analytics.untypedTrack('click_open_in_new_tab', {
+          location: 'header',
+        });
+        void analytics.identify(undefined, { hasVisitedFullPageMode: true });
+        openIndexPageInNewTab(location.pathname);
+      }}
+    >
+      <ExpandIcon />
+    </Box>
+  );
+}

--- a/src/app/features/container/headers/home.header.tsx
+++ b/src/app/features/container/headers/home.header.tsx
@@ -3,6 +3,8 @@ import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { BarsTwoIcon } from '@leather.io/ui';
 
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
+import { whenPageMode } from '@app/common/utils';
+import { FullScreenButton } from '@app/components/full-screen-button';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderGrid, HeaderGridRightCol } from '@app/components/layout/headers/header-grid';
 import { LogoBox } from '@app/components/layout/headers/logo-box';
@@ -17,6 +19,7 @@ export function HomeHeader() {
         leftCol={<LogoBox hideBelow={undefined} />}
         rightCol={
           <HeaderGridRightCol>
+            {whenPageMode({ full: null, popup: <FullScreenButton /> })}
             <Settings
               triggerButton={<BarsTwoIcon data-testid={SettingsSelectors.SettingsMenuBtn} />}
               toggleSwitchAccount={() => setIsShowingSwitchAccount(!isShowingSwitchAccount)}

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -184,6 +184,10 @@ export function Settings({
                   data-testid={SettingsSelectors.OpenWalletInNewTab}
                   onSelect={() => {
                     void analytics.track('click_open_in_new_tab_menu_item');
+                    void analytics.untypedTrack('click_open_in_new_tab', {
+                      location: 'settings-menu',
+                    });
+                    void analytics.identify(undefined, { hasVisitedFullPageMode: true });
                     openIndexPageInNewTab(location.pathname);
                   }}
                 >


### PR DESCRIPTION
> Try out Leather build 99e6c79 — [Extension build](https://github.com/leather-io/extension/actions/runs/17261763464), [Test report](https://leather-io.github.io/playwright-reports/feat/inline-fullpage-button), [Storybook](https://feat/inline-fullpage-button--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/inline-fullpage-button)<!-- Sticky Header Marker -->

In action popup mode only, we now show a header level button to access fullpage mode. We're tracking both events to see how often users opt to use this now-obvious feature.

<img width="401" height="612" alt="image" src="https://github.com/user-attachments/assets/033e3fe7-1f19-4e8c-b8e8-95a202110cf3" />
