### PR TITLE
fix: add api nonce values to report

### DIFF
--- a/.github/workflows/all-checks-pass.yml
+++ b/.github/workflows/all-checks-pass.yml
@@ -19,4 +19,7 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@v1
         with:
+          delay: 4
+          retries: 20
+          polling_interval: 1
           checks_exclude: 'Dependabot'

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@leather.io/stacks": "1.15.0",
     "@leather.io/tokens": "0.23.0",
     "@leather.io/ui": "1.78.0",
-    "@leather.io/utils": "0.42.3",
+    "@leather.io/utils": "0.44.0",
     "@ledgerhq/hw-transport-webusb": "6.27.19",
     "@noble/hashes": "1.5.0",
     "@noble/secp256k1": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         version: 0.7.0(encoding@0.1.13)
       '@coinbase/cbpay-js':
         specifier: 2.1.0
-        version: 2.1.0(regenerator-runtime@0.13.11)
+        version: 2.1.0(regenerator-runtime@0.14.1)
       '@fungible-systems/zone-file':
         specifier: 2.0.0
         version: 2.0.0
@@ -87,10 +87,10 @@ importers:
         version: 0.23.0
       '@leather.io/ui':
         specifier: 1.78.0
-        version: 1.78.0(@babel/core@7.28.0)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.18)(graphql@16.11.0)
+        version: 1.78.0(@babel/core@7.28.0)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.20)(graphql@16.11.0)
       '@leather.io/utils':
-        specifier: 0.42.3
-        version: 0.42.3
+        specifier: 0.44.0
+        version: 0.44.0
       '@ledgerhq/hw-transport-webusb':
         specifier: 6.27.19
         version: 6.27.19
@@ -421,13 +421,13 @@ importers:
         version: 3.2.2(react@19.0.0)(storybook@8.4.4(prettier@3.3.3))
       '@leather.io/eslint-config':
         specifier: 0.10.0
-        version: 0.10.0(eslint-config-prettier@10.1.8(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@16.3.0)(typescript-eslint@8.39.1(eslint@8.56.0)(typescript@5.4.5))
+        version: 0.10.0(eslint-config-prettier@10.1.8(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@16.3.0)(typescript-eslint@8.41.0(eslint@8.56.0)(typescript@5.4.5))
       '@leather.io/panda-preset':
         specifier: 0.12.9
         version: 0.12.9(jsdom@26.1.0)(typescript@5.4.5)
       '@leather.io/prettier-config':
         specifier: 0.6.1
-        version: 0.6.1(@vue/compiler-sfc@3.5.18)
+        version: 0.6.1(@vue/compiler-sfc@3.5.20)
       '@ls-lint/ls-lint':
         specifier: 2.2.3
         version: 2.2.3
@@ -706,10 +706,10 @@ importers:
         version: 1.1.2
       web-ext:
         specifier: 7.8.0
-        version: 7.8.0(body-parser@1.20.3)
+        version: 7.8.0(body-parser@2.2.0)
       web-ext-submit:
         specifier: 7.8.0
-        version: 7.8.0(body-parser@1.20.3)
+        version: 7.8.0(body-parser@2.2.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(@swc/core@1.11.21)(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.94.0))
@@ -883,6 +883,10 @@ packages:
 
   '@babel/generator@7.28.0':
     resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.3':
+    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -1091,6 +1095,11 @@ packages:
 
   '@babel/parser@7.28.0':
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1919,6 +1928,10 @@ packages:
 
   '@babel/traverse@7.28.0':
     resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.28.3':
+    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.17.0':
@@ -3401,6 +3414,9 @@ packages:
   '@leather.io/constants@0.25.1':
     resolution: {integrity: sha512-74a/PQBkauRutvhw1McQW4fqMF6o3hiNvHqClH2pqcTS44YB0QzY3H/gG0W4tA2/B+KFiZ/UmTlneop0thzpkA==}
 
+  '@leather.io/constants@0.25.2':
+    resolution: {integrity: sha512-pvov0zHVWSt5JwUc1kSIEm9tRhTrjjwXV3DKs0/TxPdytteWHsXl9HTMD9EVgNDf1g/kfzL2TyN4SZ3rTd9n9Q==}
+
   '@leather.io/crypto@1.11.5':
     resolution: {integrity: sha512-XnY4eTQyTopGQFJPQq2DB+iD0qzWfhn9o//Gmpo4DEm5XIN0M6qNSyLrvUg+FMNA3ZFUnUPVtQ7443XC4VHD+A==}
 
@@ -3419,6 +3435,9 @@ packages:
 
   '@leather.io/models@0.39.1':
     resolution: {integrity: sha512-tAjK+436dzGsg1Zjwpvj/igtMfAvEgSFFh/t9BVE4Dm1HhfIe/mKwmGdr5d8X4bi+wraZ6/iohTyFpmFl2HizA==}
+
+  '@leather.io/models@0.40.0':
+    resolution: {integrity: sha512-LWdiuCIjF1PfdvpRMOOC/pOOyMZbiBHWxXllPIG0/ZndXC2L9VmqH7McYv5iJA8ff3mTNUxWO0RKqNDJk9AQFw==}
 
   '@leather.io/panda-preset@0.12.9':
     resolution: {integrity: sha512-tGBf8ELVJ7LF/q7OmJEPKQMJ/HISoI2470yPhlw7xC7ZBt5pfEy6nZFlrl377f2copsWI3LuTKfCMBeb/k8NIg==}
@@ -3458,6 +3477,9 @@ packages:
 
   '@leather.io/utils@0.42.4':
     resolution: {integrity: sha512-SahuX0KSRl5TzoC1Vl8pJsVpTr925wbYHd5DF/upXDR6mIsEWoSK3EBBIsJd0RcGFnf5WMUn1OTWT5e3o297DA==}
+
+  '@leather.io/utils@0.44.0':
+    resolution: {integrity: sha512-rcJq+KF9+2RJkpYiLNL2R3q6dIkJ4/cpFdTjjhXf2dFdN6qCGXRTy1Scmp+5/FEix37iwUCVi8ah+53eMVTkHg==}
 
   '@ledgerhq/devices@8.4.4':
     resolution: {integrity: sha512-sz/ryhe/R687RHtevIE9RlKaV8kkKykUV4k29e7GAVwzHX1gqG+O75cu1NCJUHLbp3eABV5FdvZejqRUlLis9A==}
@@ -4783,41 +4805,41 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@react-native-community/cli-clean@20.0.0':
-    resolution: {integrity: sha512-YmdNRcT+Dp8lC7CfxSDIfPMbVPEXVFzBH62VZNbYGxjyakqAvoQUFTYPgM2AyFusAr4wDFbDOsEv88gCDwR3ig==}
+  '@react-native-community/cli-clean@20.0.1':
+    resolution: {integrity: sha512-/4Q28dDz9k++cbTSDiEQ+i2n4XlRy1keXi8VIpGVTRxAuxX+KNtNlCk5MnmPoiOZDvaRRc7xTUebUCMC03HFeQ==}
 
-  '@react-native-community/cli-config-android@20.0.0':
-    resolution: {integrity: sha512-asv60qYCnL1v0QFWcG9r1zckeFlKG+14GGNyPXY72Eea7RX5Cxdx8Pb6fIPKroWH1HEWjYH9KKHksMSnf9FMKw==}
+  '@react-native-community/cli-config-android@20.0.1':
+    resolution: {integrity: sha512-2Opfc38FZq2chMXUSY75Fzcgwe2G96sd1O4sAkq7UeoP6HGjAT2hh4xu3lzTmevUhS0T5EzIDUdYT55wTJf60A==}
 
-  '@react-native-community/cli-config-apple@20.0.0':
-    resolution: {integrity: sha512-PS1gNOdpeQ6w7dVu1zi++E+ix2D0ZkGC2SQP6Y/Qp002wG4se56esLXItYiiLrJkhH21P28fXdmYvTEkjSm9/Q==}
+  '@react-native-community/cli-config-apple@20.0.1':
+    resolution: {integrity: sha512-gtNRlNQxhA57y3vRxjTkHPusLEkLQqqkHOOE0LLeTuMQ/X8q0tdPKfFjdHDXSwjz4wXkDN327kxTPx0UPqohhg==}
 
-  '@react-native-community/cli-config@20.0.0':
-    resolution: {integrity: sha512-5Ky9ceYuDqG62VIIpbOmkg8Lybj2fUjf/5wK4UO107uRqejBgNgKsbGnIZgEhREcaSEOkujWrroJ9gweueLfBg==}
+  '@react-native-community/cli-config@20.0.1':
+    resolution: {integrity: sha512-DMjbgqFcWlCmoDAn9CgcPoEMMfRE0HgCECAeVvby+DOtcses/QxTPX1L9s2hZU16AOUSNxZEXqLzAw7pqGJl0A==}
 
-  '@react-native-community/cli-doctor@20.0.0':
-    resolution: {integrity: sha512-cPHspi59+Fy41FDVxt62ZWoicCZ1o34k8LAl64NVSY0lwPl+CEi78jipXJhtfkVqSTetloA8zexa/vSAcJy57Q==}
+  '@react-native-community/cli-doctor@20.0.1':
+    resolution: {integrity: sha512-ADzNiHpbq/CUtjJEBGQ8KxwZv7JbyIXVnsatMlP/xP5A+FbMq4YOA2FyjqSpfqha60yRMqSkc5tTLdIKtsC5yA==}
 
-  '@react-native-community/cli-platform-android@20.0.0':
-    resolution: {integrity: sha512-th3ji1GRcV6ACelgC0wJtt9daDZ+63/52KTwL39xXGoqczFjml4qERK90/ppcXU0Ilgq55ANF8Pr+UotQ2AB/A==}
+  '@react-native-community/cli-platform-android@20.0.1':
+    resolution: {integrity: sha512-Rfyi1J+TKTiDjiZ2JpodwQHp5ETv7MWoOcWLK4JeeBHQLCYlVII+7RSg44tFc0JC2/bCXscqfQOR1aYZr0sPTg==}
 
-  '@react-native-community/cli-platform-apple@20.0.0':
-    resolution: {integrity: sha512-rZZCnAjUHN1XBgiWTAMwEKpbVTO4IHBSecdd1VxJFeTZ7WjmstqA6L/HXcnueBgxrzTCRqvkRIyEQXxC1OfhGw==}
+  '@react-native-community/cli-platform-apple@20.0.1':
+    resolution: {integrity: sha512-pzPsdmYhVrg9oluL0ofWopVrbzYOJg+RBoJuoBOjpI7JWUduS8A3uLUAR8ysT+lo1x0+aztD4App9nKyY+vfbw==}
 
-  '@react-native-community/cli-platform-ios@20.0.0':
-    resolution: {integrity: sha512-Z35M+4gUJgtS4WqgpKU9/XYur70nmj3Q65c9USyTq6v/7YJ4VmBkmhC9BticPs6wuQ9Jcv0NyVCY0Wmh6kMMYw==}
+  '@react-native-community/cli-platform-ios@20.0.1':
+    resolution: {integrity: sha512-kvpUBcqOC5CE8xWCoimyP2M/gr3TVeoLRKhliixnpx7fc9cB6R6GWHgzrNDVf4z5SAQW64UFvswquPo3dk+YOg==}
 
-  '@react-native-community/cli-server-api@20.0.0':
-    resolution: {integrity: sha512-Ves21bXtjUK3tQbtqw/NdzpMW1vR2HvYCkUQ/MXKrJcPjgJnXQpSnTqHXz6ZdBlMbbwLJXOhSPiYzxb5/v4CDg==}
+  '@react-native-community/cli-server-api@20.0.1':
+    resolution: {integrity: sha512-x5wr71LJzVBGLVLFPU9iGBkY1Raw2RCd1KDKKnbYMbX/KiAgYnhW3flF0RIX+LpIkdZ8hIIcj7SETaByAAR1FA==}
 
-  '@react-native-community/cli-tools@20.0.0':
-    resolution: {integrity: sha512-akSZGxr1IajJ8n0YCwQoA3DI0HttJ0WB7M3nVpb0lOM+rJpsBN7WG5Ft+8ozb6HyIPX+O+lLeYazxn5VNG/Xhw==}
+  '@react-native-community/cli-tools@20.0.1':
+    resolution: {integrity: sha512-yrSOkVfGm8yG88DRc4DjfM4XFmRpIXGkB1StKfU8aUPzO5Pbp8cobYYdsCeK234vp9/SZu535uRrno6Or53+Jw==}
 
-  '@react-native-community/cli-types@20.0.0':
-    resolution: {integrity: sha512-7J4hzGWOPTBV1d30Pf2NidV+bfCWpjfCOiGO3HUhz1fH4MvBM0FbbBmE9LE5NnMz7M8XSRSi68ZGYQXgLBB2Qw==}
+  '@react-native-community/cli-types@20.0.1':
+    resolution: {integrity: sha512-nvIk3axp9gXyZ3Ri4UrfiCam8bYWOL0z4B1pOhSKW/9wrg2v2E9SK27xf3GZGAP/XuWKT7tuyRWHx1KZEQsfkg==}
 
-  '@react-native-community/cli@20.0.0':
-    resolution: {integrity: sha512-/cMnGl5V1rqnbElY1Fvga1vfw0d3bnqiJLx2+2oh7l9ulnXfVRWb5tU2kgBqiMxuDOKA+DQoifC9q/tvkj5K2w==}
+  '@react-native-community/cli@20.0.1':
+    resolution: {integrity: sha512-Q7UnBqOO/JsWfgmO9qZjrKgMi/0U9ih0FywXXheml8VH1hn/pBXKIeO/BvzA6g5gHIvBZ/6KyhdGoNok1R/ZJw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6443,11 +6465,11 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/eslint-plugin@8.39.1':
-    resolution: {integrity: sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==}
+  '@typescript-eslint/eslint-plugin@8.41.0':
+    resolution: {integrity: sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.39.1
+      '@typescript-eslint/parser': ^8.41.0
       eslint: 8.56.0
       typescript: '>=4.8.4 <6.0.0'
 
@@ -6461,15 +6483,15 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.39.1':
-    resolution: {integrity: sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==}
+  '@typescript-eslint/parser@8.41.0':
+    resolution: {integrity: sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.39.1':
-    resolution: {integrity: sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==}
+  '@typescript-eslint/project-service@8.41.0':
+    resolution: {integrity: sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -6486,12 +6508,12 @@ packages:
     resolution: {integrity: sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.39.1':
-    resolution: {integrity: sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==}
+  '@typescript-eslint/scope-manager@8.41.0':
+    resolution: {integrity: sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.39.1':
-    resolution: {integrity: sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==}
+  '@typescript-eslint/tsconfig-utils@8.41.0':
+    resolution: {integrity: sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -6506,8 +6528,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/type-utils@8.39.1':
-    resolution: {integrity: sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==}
+  '@typescript-eslint/type-utils@8.41.0':
+    resolution: {integrity: sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
@@ -6525,8 +6547,8 @@ packages:
     resolution: {integrity: sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.39.1':
-    resolution: {integrity: sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==}
+  '@typescript-eslint/types@8.41.0':
+    resolution: {integrity: sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@6.21.0':
@@ -6553,8 +6575,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/typescript-estree@8.39.1':
-    resolution: {integrity: sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==}
+  '@typescript-eslint/typescript-estree@8.41.0':
+    resolution: {integrity: sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -6578,8 +6600,8 @@ packages:
       eslint: 8.56.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/utils@8.39.1':
-    resolution: {integrity: sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==}
+  '@typescript-eslint/utils@8.41.0':
+    resolution: {integrity: sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
@@ -6597,8 +6619,8 @@ packages:
     resolution: {integrity: sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.39.1':
-    resolution: {integrity: sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==}
+  '@typescript-eslint/visitor-keys@8.41.0':
+    resolution: {integrity: sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -6670,32 +6692,32 @@ packages:
   '@vue/compiler-core@3.4.19':
     resolution: {integrity: sha512-gj81785z0JNzRcU0Mq98E56e4ltO1yf8k5PQ+tV/7YHnbZkrM0fyFyuttnN8ngJZjbpofWE/m4qjKBiLl8Ju4w==}
 
-  '@vue/compiler-core@3.5.18':
-    resolution: {integrity: sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==}
+  '@vue/compiler-core@3.5.20':
+    resolution: {integrity: sha512-8TWXUyiqFd3GmP4JTX9hbiTFRwYHgVL/vr3cqhr4YQ258+9FADwvj7golk2sWNGHR67QgmCZ8gz80nQcMokhwg==}
 
   '@vue/compiler-dom@3.4.19':
     resolution: {integrity: sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==}
 
-  '@vue/compiler-dom@3.5.18':
-    resolution: {integrity: sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==}
+  '@vue/compiler-dom@3.5.20':
+    resolution: {integrity: sha512-whB44M59XKjqUEYOMPYU0ijUV0G+4fdrHVKDe32abNdX/kJe1NUEMqsi4cwzXa9kyM9w5S8WqFsrfo1ogtBZGQ==}
 
   '@vue/compiler-sfc@3.4.19':
     resolution: {integrity: sha512-LQ3U4SN0DlvV0xhr1lUsgLCYlwQfUfetyPxkKYu7dkfvx7g3ojrGAkw0AERLOKYXuAGnqFsEuytkdcComei3Yg==}
 
-  '@vue/compiler-sfc@3.5.18':
-    resolution: {integrity: sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==}
+  '@vue/compiler-sfc@3.5.20':
+    resolution: {integrity: sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==}
 
   '@vue/compiler-ssr@3.4.19':
     resolution: {integrity: sha512-P0PLKC4+u4OMJ8sinba/5Z/iDT84uMRRlrWzadgLA69opCpI1gG4N55qDSC+dedwq2fJtzmGald05LWR5TFfLw==}
 
-  '@vue/compiler-ssr@3.5.18':
-    resolution: {integrity: sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==}
+  '@vue/compiler-ssr@3.5.20':
+    resolution: {integrity: sha512-RSl5XAMc5YFUXpDQi+UQDdVjH9FnEpLDHIALg5J0ITHxkEzJ8uQLlo7CIbjPYqmZtt6w0TsIPbo1izYXwDG7JA==}
 
   '@vue/shared@3.4.19':
     resolution: {integrity: sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==}
 
-  '@vue/shared@3.5.18':
-    resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
+  '@vue/shared@3.5.20':
+    resolution: {integrity: sha512-SoRGP596KU/ig6TfgkCMbXkr4YJ91n/QSdMuqeP5r3hVIYA3CPHUBCc7Skak0EAKV+5lL4KyIh61VA/pK1CIAA==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -7382,6 +7404,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
 
   bonjour-service@1.3.0:
     resolution: {integrity: sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==}
@@ -11273,6 +11299,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.18:
+    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
+
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
@@ -11412,6 +11441,10 @@ packages:
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
 
   mem@5.1.1:
     resolution: {integrity: sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==}
@@ -11652,6 +11685,10 @@ packages:
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -12949,6 +12986,10 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
   rc@1.2.8:
@@ -14565,6 +14606,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -14593,8 +14638,8 @@ packages:
   typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
 
-  typescript-eslint@8.39.1:
-    resolution: {integrity: sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==}
+  typescript-eslint@8.41.0:
+    resolution: {integrity: sha512-n66rzs5OBXW3SFSnZHr2T685q1i4ODm2nulFJhMZBotaTavsS8TrI3d7bDlRSs9yWo7HmyWrN9qDu14Qv7Y0Dw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
@@ -15648,6 +15693,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
 
+  '@babel/generator@7.28.3':
+    dependencies:
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
       '@babel/types': 7.27.6
@@ -15917,6 +15970,10 @@ snapshots:
       '@babel/types': 7.27.6
 
   '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
+
+  '@babel/parser@7.28.3':
     dependencies:
       '@babel/types': 7.28.2
 
@@ -16940,6 +16997,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.28.3':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.3
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.17.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -17052,9 +17121,9 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.13.11)':
+  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.14.1)':
     optionalDependencies:
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.14.1
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -18094,11 +18163,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@expo/vector-icons@14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -18152,22 +18221,22 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@gorhom/bottom-sheet@5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@gorhom/bottom-sheet@5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@gorhom/portal': 1.0.14(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@gorhom/portal': 1.0.14(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-reanimated: 3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-reanimated: 3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       '@types/react': 19.0.12
 
-  '@gorhom/portal@1.0.14(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@gorhom/portal@1.0.14(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
       nanoid: 3.3.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
   '@graphql-tools/merge@8.4.2(graphql@16.11.0)':
     dependencies:
@@ -18402,6 +18471,10 @@ snapshots:
     dependencies:
       '@leather.io/models': 0.39.1
 
+  '@leather.io/constants@0.25.2':
+    dependencies:
+      '@leather.io/models': 0.40.0
+
   '@leather.io/crypto@1.11.5':
     dependencies:
       '@leather.io/utils': 0.42.3
@@ -18409,14 +18482,14 @@ snapshots:
       '@scure/bip39': 1.5.4
       just-memoize: 2.2.0
 
-  '@leather.io/eslint-config@0.10.0(eslint-config-prettier@10.1.8(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@16.3.0)(typescript-eslint@8.39.1(eslint@8.56.0)(typescript@5.4.5))':
+  '@leather.io/eslint-config@0.10.0(eslint-config-prettier@10.1.8(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@16.3.0)(typescript-eslint@8.41.0(eslint@8.56.0)(typescript@5.4.5))':
     dependencies:
       eslint: 8.56.0
       eslint-config-prettier: 10.1.8(eslint@8.56.0)
       eslint-plugin-react: 7.34.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
       globals: 16.3.0
-      typescript-eslint: 8.39.1(eslint@8.56.0)(typescript@5.4.5)
+      typescript-eslint: 8.41.0(eslint@8.56.0)(typescript@5.4.5)
 
   '@leather.io/models@0.39.0':
     dependencies:
@@ -18430,6 +18503,12 @@ snapshots:
       bignumber.js: 9.1.2
       zod: 4.0.17
 
+  '@leather.io/models@0.40.0':
+    dependencies:
+      '@stacks/stacks-blockchain-api-types': 7.14.1
+      bignumber.js: 9.1.2
+      zod: 4.0.17
+
   '@leather.io/panda-preset@0.12.9(jsdom@26.1.0)(typescript@5.4.5)':
     dependencies:
       '@pandacss/dev': 0.53.6(jsdom@26.1.0)(typescript@5.4.5)
@@ -18437,17 +18516,17 @@ snapshots:
       - jsdom
       - typescript
 
-  '@leather.io/prettier-config@0.6.1(@vue/compiler-sfc@3.5.18)':
+  '@leather.io/prettier-config@0.6.1(@vue/compiler-sfc@3.5.20)':
     dependencies:
-      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.18)(prettier@3.5.1)
+      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.20)(prettier@3.5.1)
       prettier: 3.5.1
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/prettier-config@0.8.1(@vue/compiler-sfc@3.5.18)':
+  '@leather.io/prettier-config@0.8.1(@vue/compiler-sfc@3.5.20)':
     dependencies:
-      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.18)(prettier@3.5.1)
+      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.20)(prettier@3.5.1)
       prettier: 3.5.1
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
@@ -18567,39 +18646,39 @@ snapshots:
 
   '@leather.io/tokens@0.23.0': {}
 
-  '@leather.io/ui@1.78.0(@babel/core@7.28.0)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.18)(graphql@16.11.0)':
+  '@leather.io/ui@1.78.0(@babel/core@7.28.0)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.20)(graphql@16.11.0)':
     dependencies:
-      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      '@gorhom/bottom-sheet': 5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      '@leather.io/prettier-config': 0.8.1(@vue/compiler-sfc@3.5.18)
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@gorhom/bottom-sheet': 5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@leather.io/prettier-config': 0.8.1(@vue/compiler-sfc@3.5.20)
       '@leather.io/tokens': 0.23.0
       '@leather.io/utils': 0.42.4
       '@react-native/assets-registry': 0.73.1
       '@rnx-kit/metro-resolver-symlinks': 0.2.3
-      '@shopify/restyle': 2.4.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@shopify/restyle': 2.4.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       dompurify: 3.2.4
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-blur: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
-      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      expo-haptics: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
-      expo-image: 2.1.7(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-linear-gradient: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-splash-screen: 0.30.8(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
-      expo-squircle-view: 1.1.0(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-blur: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-haptics: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
+      expo-image: 2.1.7(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-linear-gradient: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-splash-screen: 0.30.8(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
+      expo-squircle-view: 1.1.0(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       framer-motion: 12.11.0(@emotion/is-prop-valid@1.3.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       prism-react-renderer: 2.4.1(react@19.0.0)
       prismjs: 1.29.0
       radix-ui: 1.3.4(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-reanimated: 3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.4.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.11.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-reanimated: 3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.4.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.11.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       use-events: 1.4.2(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -18630,6 +18709,13 @@ snapshots:
     dependencies:
       '@leather.io/constants': 0.25.1
       '@leather.io/models': 0.39.1
+      bignumber.js: 9.1.2
+      dompurify: 3.2.4
+
+  '@leather.io/utils@0.44.0':
+    dependencies:
+      '@leather.io/constants': 0.25.2
+      '@leather.io/models': 0.40.0
       bignumber.js: 9.1.2
       dompurify: 3.2.4
 
@@ -20316,33 +20402,33 @@ snapshots:
       '@types/react': 19.0.12
       '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
-  '@react-native-community/cli-clean@20.0.0':
+  '@react-native-community/cli-clean@20.0.1':
     dependencies:
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.3
     optional: true
 
-  '@react-native-community/cli-config-android@20.0.0':
+  '@react-native-community/cli-config-android@20.0.1':
     dependencies:
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       fast-glob: 3.3.3
       fast-xml-parser: 4.4.1
     optional: true
 
-  '@react-native-community/cli-config-apple@20.0.0':
+  '@react-native-community/cli-config-apple@20.0.1':
     dependencies:
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.3
     optional: true
 
-  '@react-native-community/cli-config@20.0.0(typescript@5.4.5)':
+  '@react-native-community/cli-config@20.0.1(typescript@5.4.5)':
     dependencies:
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       cosmiconfig: 9.0.0(typescript@5.4.5)
       deepmerge: 4.3.1
@@ -20352,13 +20438,13 @@ snapshots:
       - typescript
     optional: true
 
-  '@react-native-community/cli-doctor@20.0.0(typescript@5.4.5)':
+  '@react-native-community/cli-doctor@20.0.1(typescript@5.4.5)':
     dependencies:
-      '@react-native-community/cli-config': 20.0.0(typescript@5.4.5)
-      '@react-native-community/cli-platform-android': 20.0.0
-      '@react-native-community/cli-platform-apple': 20.0.0
-      '@react-native-community/cli-platform-ios': 20.0.0
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-config': 20.0.1(typescript@5.4.5)
+      '@react-native-community/cli-platform-android': 20.0.1
+      '@react-native-community/cli-platform-apple': 20.0.1
+      '@react-native-community/cli-platform-ios': 20.0.1
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       command-exists: 1.2.9
       deepmerge: 4.3.1
@@ -20373,32 +20459,32 @@ snapshots:
       - typescript
     optional: true
 
-  '@react-native-community/cli-platform-android@20.0.0':
+  '@react-native-community/cli-platform-android@20.0.1':
     dependencies:
-      '@react-native-community/cli-config-android': 20.0.0
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-config-android': 20.0.1
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       execa: 5.1.1
       logkitty: 0.7.1
     optional: true
 
-  '@react-native-community/cli-platform-apple@20.0.0':
+  '@react-native-community/cli-platform-apple@20.0.1':
     dependencies:
-      '@react-native-community/cli-config-apple': 20.0.0
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-config-apple': 20.0.1
+      '@react-native-community/cli-tools': 20.0.1
       chalk: 4.1.2
       execa: 5.1.1
       fast-xml-parser: 4.4.1
     optional: true
 
-  '@react-native-community/cli-platform-ios@20.0.0':
+  '@react-native-community/cli-platform-ios@20.0.1':
     dependencies:
-      '@react-native-community/cli-platform-apple': 20.0.0
+      '@react-native-community/cli-platform-apple': 20.0.1
     optional: true
 
-  '@react-native-community/cli-server-api@20.0.0':
+  '@react-native-community/cli-server-api@20.0.1':
     dependencies:
-      '@react-native-community/cli-tools': 20.0.0
+      '@react-native-community/cli-tools': 20.0.1
       body-parser: 1.20.3
       compression: 1.8.1
       connect: 3.7.0
@@ -20414,7 +20500,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@react-native-community/cli-tools@20.0.0':
+  '@react-native-community/cli-tools@20.0.1':
     dependencies:
       '@vscode/sudo-prompt': 9.3.1
       appdirsjs: 1.2.7
@@ -20428,19 +20514,19 @@ snapshots:
       semver: 7.7.2
     optional: true
 
-  '@react-native-community/cli-types@20.0.0':
+  '@react-native-community/cli-types@20.0.1':
     dependencies:
       joi: 17.13.3
     optional: true
 
-  '@react-native-community/cli@20.0.0(typescript@5.4.5)':
+  '@react-native-community/cli@20.0.1(typescript@5.4.5)':
     dependencies:
-      '@react-native-community/cli-clean': 20.0.0
-      '@react-native-community/cli-config': 20.0.0(typescript@5.4.5)
-      '@react-native-community/cli-doctor': 20.0.0(typescript@5.4.5)
-      '@react-native-community/cli-server-api': 20.0.0
-      '@react-native-community/cli-tools': 20.0.0
-      '@react-native-community/cli-types': 20.0.0
+      '@react-native-community/cli-clean': 20.0.1
+      '@react-native-community/cli-config': 20.0.1(typescript@5.4.5)
+      '@react-native-community/cli-doctor': 20.0.1(typescript@5.4.5)
+      '@react-native-community/cli-server-api': 20.0.1
+      '@react-native-community/cli-tools': 20.0.1
+      '@react-native-community/cli-types': 20.0.1
       chalk: 4.1.2
       commander: 9.5.0
       deepmerge: 4.3.1
@@ -20528,7 +20614,7 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.79.2(@react-native-community/cli@20.0.0(typescript@5.4.5))':
+  '@react-native/community-cli-plugin@0.79.2(@react-native-community/cli@20.0.1(typescript@5.4.5))':
     dependencies:
       '@react-native/dev-middleware': 0.79.2
       chalk: 4.1.2
@@ -20539,7 +20625,7 @@ snapshots:
       metro-core: 0.82.5
       semver: 7.7.2
     optionalDependencies:
-      '@react-native-community/cli': 20.0.0(typescript@5.4.5)
+      '@react-native-community/cli': 20.0.1(typescript@5.4.5)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -20573,12 +20659,12 @@ snapshots:
 
   '@react-native/normalize-colors@0.79.5': {}
 
-  '@react-native/virtualized-lists@0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@react-native/virtualized-lists@0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
     optionalDependencies:
       '@types/react': 19.0.12
 
@@ -21200,10 +21286,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@shopify/restyle@2.4.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@shopify/restyle@2.4.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -22116,7 +22202,7 @@ snapshots:
   '@tootallnate/once@1.1.2':
     optional: true
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.18)(prettier@3.5.1)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.20)(prettier@3.5.1)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.27.5
@@ -22126,7 +22212,7 @@ snapshots:
       lodash: 4.17.21
       prettier: 3.5.1
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.20
     transitivePeerDependencies:
       - supports-color
 
@@ -22753,14 +22839,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.1(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 8.39.1
-      '@typescript-eslint/type-utils': 8.39.1(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.39.1(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.39.1
+      '@typescript-eslint/parser': 8.41.0(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/type-utils': 8.41.0(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.41.0(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.41.0
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 7.0.5
@@ -22783,22 +22869,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.39.1(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.41.0(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.39.1
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.39.1
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.41.0
       debug: 4.4.1
       eslint: 8.56.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.1(typescript@5.4.5)':
+  '@typescript-eslint/project-service@8.41.0(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.4.5)
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.4.5)
+      '@typescript-eslint/types': 8.41.0
       debug: 4.4.1
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -22819,12 +22905,12 @@ snapshots:
       '@typescript-eslint/types': 8.31.1
       '@typescript-eslint/visitor-keys': 8.31.1
 
-  '@typescript-eslint/scope-manager@8.39.1':
+  '@typescript-eslint/scope-manager@8.41.0':
     dependencies:
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/visitor-keys': 8.39.1
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/visitor-keys': 8.41.0
 
-  '@typescript-eslint/tsconfig-utils@8.39.1(typescript@5.4.5)':
+  '@typescript-eslint/tsconfig-utils@8.41.0(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
@@ -22840,11 +22926,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.39.1(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.41.0(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.39.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.41.0(eslint@8.56.0)(typescript@5.4.5)
       debug: 4.4.1
       eslint: 8.56.0
       ts-api-utils: 2.1.0(typescript@5.4.5)
@@ -22858,7 +22944,7 @@ snapshots:
 
   '@typescript-eslint/types@8.31.1': {}
 
-  '@typescript-eslint/types@8.39.1': {}
+  '@typescript-eslint/types@8.41.0': {}
 
   '@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.5)':
     dependencies:
@@ -22904,12 +22990,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.39.1(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@8.41.0(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.1(typescript@5.4.5)
-      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.4.5)
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/visitor-keys': 8.39.1
+      '@typescript-eslint/project-service': 8.41.0(typescript@5.4.5)
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.4.5)
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/visitor-keys': 8.41.0
       debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -22959,12 +23045,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.39.1(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.41.0(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.56.0)
-      '@typescript-eslint/scope-manager': 8.39.1
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.4.5)
       eslint: 8.56.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -22985,9 +23071,9 @@ snapshots:
       '@typescript-eslint/types': 8.31.1
       eslint-visitor-keys: 4.2.0
 
-  '@typescript-eslint/visitor-keys@8.39.1':
+  '@typescript-eslint/visitor-keys@8.41.0':
     dependencies:
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/types': 8.41.0
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -23103,10 +23189,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.5.18':
+  '@vue/compiler-core@3.5.20':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.28.3
+      '@vue/shared': 3.5.20
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -23117,10 +23203,10 @@ snapshots:
       '@vue/compiler-core': 3.4.19
       '@vue/shared': 3.4.19
 
-  '@vue/compiler-dom@3.5.18':
+  '@vue/compiler-dom@3.5.20':
     dependencies:
-      '@vue/compiler-core': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/compiler-core': 3.5.20
+      '@vue/shared': 3.5.20
     optional: true
 
   '@vue/compiler-sfc@3.4.19':
@@ -23135,15 +23221,15 @@ snapshots:
       postcss: 8.4.47
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.5.18':
+  '@vue/compiler-sfc@3.5.20':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/compiler-core': 3.5.18
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.28.3
+      '@vue/compiler-core': 3.5.20
+      '@vue/compiler-dom': 3.5.20
+      '@vue/compiler-ssr': 3.5.20
+      '@vue/shared': 3.5.20
       estree-walker: 2.0.2
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
@@ -23153,15 +23239,15 @@ snapshots:
       '@vue/compiler-dom': 3.4.19
       '@vue/shared': 3.4.19
 
-  '@vue/compiler-ssr@3.5.18':
+  '@vue/compiler-ssr@3.5.20':
     dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/compiler-dom': 3.5.20
+      '@vue/shared': 3.5.20
     optional: true
 
   '@vue/shared@3.4.19': {}
 
-  '@vue/shared@3.5.18':
+  '@vue/shared@3.5.20':
     optional: true
 
   '@webassemblyjs/ast@1.14.1':
@@ -23317,12 +23403,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  addons-linter@6.13.0(body-parser@1.20.3)(node-fetch@3.3.1):
+  addons-linter@6.13.0(body-parser@2.2.0)(node-fetch@3.3.1):
     dependencies:
       '@fluent/syntax': 0.19.0
       '@mdn/browser-compat-data': 5.3.14
       addons-moz-compare: 1.3.0
-      addons-scanner-utils: 9.3.0(body-parser@1.20.3)(node-fetch@3.3.1)
+      addons-scanner-utils: 9.3.0(body-parser@2.2.0)(node-fetch@3.3.1)
       ajv: 8.12.0
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
@@ -23360,7 +23446,7 @@ snapshots:
 
   addons-moz-compare@1.3.0: {}
 
-  addons-scanner-utils@9.3.0(body-parser@1.20.3)(node-fetch@3.3.1):
+  addons-scanner-utils@9.3.0(body-parser@2.2.0)(node-fetch@3.3.1):
     dependencies:
       '@types/yauzl': 2.10.0
       common-tags: 1.8.2
@@ -23369,7 +23455,7 @@ snapshots:
       upath: 2.0.1
       yauzl: 2.10.0
     optionalDependencies:
-      body-parser: 1.20.3
+      body-parser: 2.2.0
       node-fetch: 3.3.1
 
   address@1.2.2: {}
@@ -24013,6 +24099,21 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.1
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   bonjour-service@1.3.0:
     dependencies:
@@ -26230,62 +26331,62 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  expo-asset@11.1.5(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-asset@11.1.5(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@expo/image-utils': 0.7.6
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-blur@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-blur@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  expo-constants@17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)):
+  expo-constants@17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)):
     dependencies:
       '@expo/config': 11.0.13
       '@expo/env': 1.0.7
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-file-system@18.1.11(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)):
+  expo-file-system@18.1.11(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       fontfaceobserver: 2.3.0
       react: 19.0.0
 
-  expo-haptics@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
+  expo-haptics@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
 
-  expo-image@2.1.7(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-image@2.1.7(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
-  expo-linear-gradient@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-linear-gradient@14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
   expo-modules-autolinking@2.1.10:
     dependencies:
@@ -26301,20 +26402,20 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-splash-screen@0.30.8(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
+  expo-splash-screen@0.30.8(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
     dependencies:
       '@expo/prebuild-config': 9.0.11
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-squircle-view@1.1.0(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-squircle-view@1.1.0(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.28.2
       '@expo/cli': 0.24.13(graphql@16.11.0)
@@ -26322,21 +26423,21 @@ snapshots:
       '@expo/config-plugins': 10.0.3
       '@expo/fingerprint': 0.12.4
       '@expo/metro-config': 0.20.14
-      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       babel-preset-expo: 13.1.11(@babel/core@7.28.0)
-      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
-      expo-file-system: 18.1.11(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
-      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      expo-keep-awake: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
+      expo-file-system: 18.1.11(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-keep-awake: 14.1.4(expo@53.0.9(@babel/core@7.28.0)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       expo-modules-autolinking: 2.1.10
       expo-modules-core: 2.3.13
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-edge-to-edge: 1.6.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
-      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-react-compiler
@@ -28469,6 +28570,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.18:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
+
   magic-string@0.30.8:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -28738,6 +28844,9 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0:
+    optional: true
+
   mem@5.1.1:
     dependencies:
       map-age-cleaner: 0.1.3
@@ -28861,7 +28970,7 @@ snapshots:
   metro-source-map@0.82.5:
     dependencies:
       '@babel/traverse': 7.28.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.0'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.3'
       '@babel/types': 7.28.2
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -29264,6 +29373,11 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
+    optional: true
 
   mime@1.6.0: {}
 
@@ -30714,6 +30828,14 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
+    optional: true
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -30860,25 +30982,25 @@ snapshots:
       lottie-web: 5.12.2
       react: 19.0.0
 
-  react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-is-edge-to-edge@1.1.7(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-is-edge-to-edge@1.1.7(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-reanimated@3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-reanimated@3.17.5(@babel/core@7.28.0)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.0)
@@ -30893,41 +31015,41 @@ snapshots:
       convert-source-map: 2.0.0
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-is-edge-to-edge: 1.1.7(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native-is-edge-to-edge: 1.1.7(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-svg@15.11.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-svg@15.11.2(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
       warn-once: 0.1.1
 
-  react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0):
+  react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.79.2
       '@react-native/codegen': 0.79.2(@babel/core@7.28.0)
-      '@react-native/community-cli-plugin': 0.79.2(@react-native-community/cli@20.0.0(typescript@5.4.5))
+      '@react-native/community-cli-plugin': 0.79.2(@react-native-community/cli@20.0.1(typescript@5.4.5))
       '@react-native/gradle-plugin': 0.79.2
       '@react-native/js-polyfills': 0.79.2
       '@react-native/normalize-colors': 0.79.2
-      '@react-native/virtualized-lists': 0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.0(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@react-native/virtualized-lists': 0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.28.0)(@react-native-community/cli@20.0.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -32671,6 +32793,13 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+    optional: true
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -32714,12 +32843,12 @@ snapshots:
 
   typeforce@1.18.0: {}
 
-  typescript-eslint@8.39.1(eslint@8.56.0)(typescript@5.4.5):
+  typescript-eslint@8.41.0(eslint@8.56.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.39.1(@typescript-eslint/parser@8.39.1(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.39.1(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.39.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.41.0(@typescript-eslint/parser@8.41.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.41.0(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.41.0(eslint@8.56.0)(typescript@5.4.5)
       eslint: 8.56.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -33207,9 +33336,9 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-ext-submit@7.8.0(body-parser@1.20.3):
+  web-ext-submit@7.8.0(body-parser@2.2.0):
     dependencies:
-      web-ext: 7.8.0(body-parser@1.20.3)
+      web-ext: 7.8.0(body-parser@2.2.0)
     transitivePeerDependencies:
       - body-parser
       - bufferutil
@@ -33218,11 +33347,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  web-ext@7.8.0(body-parser@1.20.3):
+  web-ext@7.8.0(body-parser@2.2.0):
     dependencies:
       '@babel/runtime': 7.21.0
       '@devicefarmer/adbkit': 3.2.3
-      addons-linter: 6.13.0(body-parser@1.20.3)(node-fetch@3.3.1)
+      addons-linter: 6.13.0(body-parser@2.2.0)(node-fetch@3.3.1)
       bunyan: 1.8.15
       camelcase: 7.0.1
       chrome-launcher: 0.15.1

--- a/src/app/common/transactions/stacks/stacks-broadcast-transaction.ts
+++ b/src/app/common/transactions/stacks/stacks-broadcast-transaction.ts
@@ -52,7 +52,7 @@ export async function stacksBroadcastTransaction({
     if (!response.txid) {
       logger.error('Transaction failed to broadcast', response);
       throw createError({
-        name: 'Transaction broadcast but returned no txid',
+        name: 'TransactionBroadcastError',
         message: 'Transaction broadcast but returned no txid',
       });
     }

--- a/src/app/common/transactions/stacks/stacks-broadcast-transaction.ts
+++ b/src/app/common/transactions/stacks/stacks-broadcast-transaction.ts
@@ -5,12 +5,12 @@ import {
   broadcastTransaction,
 } from '@stacks/transactions';
 
-import { delay, isError } from '@leather.io/utils';
+import { delay, flattenObject, isError } from '@leather.io/utils';
 
 import { logger } from '@shared/logger';
 import { analytics } from '@shared/utils/analytics';
 
-import { serializeError } from '@app/common/utils';
+import { createError, serializeError } from '@app/common/utils';
 import { hiroFetchWrapper } from '@app/query/stacks/stacks-client';
 
 interface StacksBroadcastTransactionArgs {
@@ -41,19 +41,20 @@ export async function stacksBroadcastTransaction({
 
     if ('error' in response) {
       logger.error('Transaction failed to broadcast', response);
-      const error = new Error(response.error);
-      error.name = response.reason;
-      error.message = response.error;
-      error.cause = response.reason;
+      const error = createError({
+        ...flattenObject(response),
+        name: response.reason,
+        message: response.error,
+      });
       throw error;
     }
 
     if (!response.txid) {
       logger.error('Transaction failed to broadcast', response);
-      const error = new Error('Transaction broadcast but returned no txid');
-      error.name = 'TransactionBroadcastError';
-      error.message = 'Transaction broadcast but returned no txid';
-      throw error;
+      throw createError({
+        name: 'Transaction broadcast but returned no txid',
+        message: 'Transaction broadcast but returned no txid',
+      });
     }
 
     logger.info('Transaction broadcast', response);

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -287,6 +287,19 @@ export function serializeError(err: unknown) {
   return { message: String(err) };
 }
 
+interface CreateErrorArgs {
+  name: string;
+  message: string;
+  [key: string]: unknown;
+}
+export function createError({ name, message, ...metadata }: CreateErrorArgs) {
+  const err = new Error(message);
+  err.name = name;
+  Object.assign(err, metadata);
+  if (Error.captureStackTrace) Error.captureStackTrace(err, createError);
+  return err;
+}
+
 export function runOnce(fn: () => void) {
   let hasRun = false;
   return () => {

--- a/src/app/components/full-screen-button.tsx
+++ b/src/app/components/full-screen-button.tsx
@@ -6,24 +6,29 @@ import { ExpandIcon } from '@leather.io/ui';
 
 import { analytics } from '@shared/utils/analytics';
 
+import { whenPageMode } from '@app/common/utils';
 import { openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
 
 export function FullScreenButton() {
   const location = useLocation();
-  return (
-    <Box
-      _hover={{ bg: 'ink.component-background-hover' }}
-      _focus={{ outline: 'none' }}
-      p="space.02"
-      onClick={() => {
-        void analytics.untypedTrack('click_open_in_new_tab', {
-          location: 'header',
-        });
-        void analytics.identify(undefined, { hasVisitedFullPageMode: true });
-        openIndexPageInNewTab(location.pathname);
-      }}
-    >
-      <ExpandIcon />
-    </Box>
-  );
+
+  return whenPageMode({
+    full: null,
+    popup: (
+      <Box
+        _hover={{ bg: 'ink.component-background-hover' }}
+        _focus={{ outline: 'none' }}
+        p="space.02"
+        onClick={() => {
+          void analytics.untypedTrack('click_open_in_new_tab', {
+            location: 'header',
+          });
+          void analytics.identify(undefined, { hasVisitedFullPageMode: true });
+          openIndexPageInNewTab(location.pathname);
+        }}
+      >
+        <ExpandIcon />
+      </Box>
+    ),
+  });
 }

--- a/src/app/components/loaders/stacks-nonce-loader.tsx
+++ b/src/app/components/loaders/stacks-nonce-loader.tsx
@@ -31,10 +31,9 @@ export function useAnalyticsOnlyStacksNonceTracker() {
 
       const serializedError = serializeError(error);
       if ('name' in serializedError && serializedError.name === 'BadNonce') {
-        void analytics.untypedTrack('investigation_bad_nonce_increase', {
-          ...serializedError,
-          ...context,
-        });
+        const report = { ...serializedError, ...context };
+        if ('stack' in report) delete report.stack;
+        void analytics.untypedTrack('investigation_bad_nonce_increase', report);
       }
     },
   };

--- a/src/app/features/container/headers/home.header.tsx
+++ b/src/app/features/container/headers/home.header.tsx
@@ -3,7 +3,6 @@ import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { BarsTwoIcon } from '@leather.io/ui';
 
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
-import { whenPageMode } from '@app/common/utils';
 import { FullScreenButton } from '@app/components/full-screen-button';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderGrid, HeaderGridRightCol } from '@app/components/layout/headers/header-grid';
@@ -19,7 +18,7 @@ export function HomeHeader() {
         leftCol={<LogoBox hideBelow={undefined} />}
         rightCol={
           <HeaderGridRightCol>
-            {whenPageMode({ full: null, popup: <FullScreenButton /> })}
+            <FullScreenButton />
             <Settings
               triggerButton={<BarsTwoIcon data-testid={SettingsSelectors.SettingsMenuBtn} />}
               toggleSwitchAccount={() => setIsShowingSwitchAccount(!isShowingSwitchAccount)}

--- a/src/app/features/container/headers/unlock.header.tsx
+++ b/src/app/features/container/headers/unlock.header.tsx
@@ -6,6 +6,7 @@ import { BarsTwoIcon } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { FullScreenButton } from '@app/components/full-screen-button';
 import { Header } from '@app/components/layout/headers/header';
 import { HeaderGrid, HeaderGridRightCol } from '@app/components/layout/headers/header-grid';
 import { LogoBox } from '@app/components/layout/headers/logo-box';
@@ -22,6 +23,7 @@ export function UnlockHeader() {
         }
         rightCol={
           <HeaderGridRightCol>
+            <FullScreenButton />
             <Settings
               canLockWallet={false}
               triggerButton={<BarsTwoIcon data-testid={SettingsSelectors.SettingsMenuBtn} />}

--- a/src/app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
+++ b/src/app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
@@ -68,19 +68,7 @@ export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
 
       function onError(error: Error | string) {
         const message = isString(error) ? error : error.message;
-
         trackIfNonceError(error);
-
-        chrome.tabs.sendMessage(
-          tabId,
-          createRpcErrorResponse(method, {
-            id: requestId,
-            error: {
-              code: RpcErrorCode.INVALID_REQUEST,
-              message: RpcErrorMessage.BroadcastError,
-            },
-          })
-        );
 
         return navigate(RouteUrls.BroadcastError, { state: { message } });
       }


### PR DESCRIPTION
> Try out Leather build 3a6723c — [Extension build](https://github.com/leather-io/extension/actions/runs/17267586949), [Test report](https://leather-io.github.io/playwright-reports/fix/enhance-nonce-analytics), [Storybook](https://fix/enhance-nonce-analytics--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/enhance-nonce-analytics)<!-- Sticky Header Marker -->

Adds some extra metadata to help diagnose nonce reports. Adds fullscreen button to unlock header too 

I've also removed a message being passed to apps onError. Since the user can retry, the action isn't over, yet returning an error rejects the promise.