### PR TITLE
Proposal: Internal use of RPC API

### DIFF
--- a/src/app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
+++ b/src/app/features/rpc-stacks-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
@@ -26,7 +26,7 @@ import { useRpcTransactionRequest } from '../use-rpc-transaction-request';
 
 export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
   const { onSetTransactionStatus } = useRpcTransactionRequest();
-  const { tabId, requestId } = useRpcRequestParams();
+  const { requestId } = useRpcRequestParams();
   const signStacksTransaction = useSignStacksTransaction();
   const network = useCurrentStacksNetworkState();
   const navigate = useNavigate();
@@ -37,8 +37,7 @@ export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
       const signedTx = await signStacksTransaction(unsignedTx);
 
       if (!signedTx) {
-        chrome.tabs.sendMessage(
-          tabId,
+        chrome.runtime.sendMessage(
           createRpcErrorResponse(method, {
             id: requestId,
             error: {
@@ -56,8 +55,7 @@ export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
       // If the transaction is sponsored, we do not broadcast it
       const isSponsored = signedTx.auth?.authType === AuthType.Sponsored;
       if (isSponsored) {
-        chrome.tabs.sendMessage(
-          tabId,
+        chrome.runtime.sendMessage(
           createRpcSuccessResponse(method, {
             id: requestId,
             result: {
@@ -80,8 +78,7 @@ export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
       async function onSuccess(txid: string, transaction: StacksTransactionWire) {
         onSetTransactionStatus('submitted');
 
-        chrome.tabs.sendMessage(
-          tabId,
+        chrome.runtime.sendMessage(
           createRpcSuccessResponse(method, {
             id: requestId,
             result: {
@@ -105,7 +102,6 @@ export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
       onSetTransactionStatus,
       requestId,
       signStacksTransaction,
-      tabId,
       trackIfNonceError,
     ]
   );

--- a/src/app/features/rpc-stacks-transaction-request/stacks/use-unsigned-transaction-for-fee-estimation.tsx
+++ b/src/app/features/rpc-stacks-transaction-request/stacks/use-unsigned-transaction-for-fee-estimation.tsx
@@ -25,8 +25,7 @@ export function useUnsignedStacksTransactionForFeeEstimation({
     [txOptions]
   );
   if (unsignedTx.error) {
-    chrome.tabs.sendMessage(
-      request.tabId,
+    chrome.runtime.sendMessage(
       createRpcErrorResponse(method, {
         id: request.requestId,
         error: {

--- a/src/app/pages/rpc-get-addresses/use-get-addresses.ts
+++ b/src/app/pages/rpc-get-addresses/use-get-addresses.ts
@@ -98,8 +98,7 @@ export function useGetAddresses() {
         keysToIncludeInResponse.push(stacksAddressResponse);
       }
 
-      chrome.tabs.sendMessage(
-        tabId,
+      chrome.runtime.sendMessage(
         createRpcSuccessResponse(request.method, {
           id: request.id,
           result: { addresses: keysToIncludeInResponse },

--- a/src/app/pages/rpc-send-transfer/use-rpc-send-transfer-actions.tsx
+++ b/src/app/pages/rpc-send-transfer/use-rpc-send-transfer-actions.tsx
@@ -20,8 +20,7 @@ import { useRpcSendTransferContext } from './rpc-send-transfer.context';
 
 export function useRpcSendTransferActions() {
   const { availableBalance, selectedFee } = useFeeEditorContext();
-  const { amount, isLoadingBalance, recipients, requestId, tabId, utxos } =
-    useRpcSendTransferContext();
+  const { amount, isLoadingBalance, recipients, requestId, utxos } = useRpcSendTransferContext();
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isBroadcasting, setIsBroadcasting] = useState(false);
   const generateTx = useGenerateUnsignedNativeSegwitTx({ throwError: true });
@@ -71,8 +70,7 @@ export function useRpcSendTransferActions() {
               amount: amount.amount.toNumber(),
             });
 
-            chrome.tabs.sendMessage(
-              tabId ?? 0,
+            chrome.runtime.sendMessage(
               createRpcSuccessResponse('sendTransfer', {
                 id: requestId,
                 result: { txid },
@@ -114,7 +112,6 @@ export function useRpcSendTransferActions() {
     signTransaction,
     broadcastTx,
     utxosOfSpendableInscriptions,
-    tabId,
     requestId,
   ]);
 

--- a/src/app/pages/rpc-sign-bip322-message/use-sign-bip322-message.ts
+++ b/src/app/pages/rpc-sign-bip322-message/use-sign-bip322-message.ts
@@ -59,7 +59,7 @@ function useSignBip322MessageFactory({ address, signPsbt }: SignBip322MessageFac
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
 
-  const { tabId, origin, requestId, message } = useRpcSignBitcoinMessage();
+  const { origin, requestId, message } = useRpcSignBitcoinMessage();
 
   return {
     origin,
@@ -68,9 +68,7 @@ function useSignBip322MessageFactory({ address, signPsbt }: SignBip322MessageFac
     formattedOrigin: new URL(origin ?? '').host,
     address,
     onUserRejectBip322MessageSigningRequest() {
-      if (!tabId) return;
-      chrome.tabs.sendMessage(
-        tabId,
+      chrome.runtime.sendMessage(
         createRpcErrorResponse('signMessage', {
           id: requestId,
           error: {
@@ -84,8 +82,8 @@ function useSignBip322MessageFactory({ address, signPsbt }: SignBip322MessageFac
     async onUserApproveBip322MessageSigningRequest() {
       setIsLoading(true);
 
-      if (!tabId || !origin) {
-        logger.error('Cannot give app accounts: missing tabId, origin');
+      if (!origin) {
+        logger.error('Cannot give app accounts: missing, origin');
         return;
       }
 
@@ -99,8 +97,7 @@ function useSignBip322MessageFactory({ address, signPsbt }: SignBip322MessageFac
       await shortPauseBeforeToast();
       toast.success('Message signed successfully');
 
-      chrome.tabs.sendMessage(
-        tabId,
+      chrome.runtime.sendMessage(
         createRpcSuccessResponse('signMessage', {
           id: requestId,
           result: { signature, address, message },

--- a/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -32,7 +32,7 @@ interface BroadcastSignedPsbtTxArgs {
 }
 export function useRpcSignPsbt() {
   const navigate = useNavigate();
-  const { broadcast, origin, psbtHex, requestId, signAtIndex, tabId } = useRpcSignPsbtParams();
+  const { broadcast, origin, psbtHex, requestId, signAtIndex } = useRpcSignPsbtParams();
   const { signPsbt, getPsbtAsTransaction } = usePsbtSigner();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
   const { filteredUtxosQuery } = useCurrentNativeSegwitUtxos();
@@ -62,8 +62,7 @@ export function useRpcSignPsbt() {
       async onSuccess(txid) {
         if (!requestId) throw new Error('Invalid request id');
 
-        chrome.tabs.sendMessage(
-          tabId,
+        chrome.runtime.sendMessage(
           createRpcSuccessResponse('signPsbt', {
             id: requestId,
             result: { hex: psbt, txid },
@@ -86,19 +85,18 @@ export function useRpcSignPsbt() {
           txValue: formatCurrency(transferTotalAsMoney),
         };
 
-        navigate(RouteUrls.RpcSignPsbtSummary, { state: psbtTxSummaryState });
+        void navigate(RouteUrls.RpcSignPsbtSummary, { state: psbtTxSummaryState });
       },
       onError(e) {
         if (!requestId) throw new Error('Invalid request id');
 
-        chrome.tabs.sendMessage(
-          tabId,
+        chrome.runtime.sendMessage(
           createRpcErrorResponse('signPsbt', {
             id: requestId,
             error: { code: 4002, message: 'Failed to broadcast transaction' },
           })
         );
-        navigate(RouteUrls.RequestError, {
+        void navigate(RouteUrls.RequestError, {
           state: { message: isError(e) ? e.message : '', title: 'Failed to broadcast' },
         });
       },
@@ -122,8 +120,7 @@ export function useRpcSignPsbt() {
         const psbt = signedTx.toPSBT();
 
         if (!broadcast) {
-          chrome.tabs.sendMessage(
-            tabId,
+          chrome.runtime.sendMessage(
             createRpcSuccessResponse('signPsbt', {
               id: requestId,
               result: { hex: bytesToHex(psbt) },
@@ -164,8 +161,7 @@ export function useRpcSignPsbt() {
       }
     },
     onCancel() {
-      chrome.tabs.sendMessage(
-        tabId,
+      chrome.runtime.sendMessage(
         createRpcErrorResponse('signPsbt', {
           id: requestId,
           error: {

--- a/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
+++ b/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
@@ -45,7 +45,7 @@ import {
 } from './rpc-stx-sign-transaction.utils';
 
 export function RpcStxSignTransaction() {
-  const { address, isLoadingBalance, requestId, tabId } = useStacksRpcTransactionRequestContext();
+  const { address, isLoadingBalance, requestId } = useStacksRpcTransactionRequestContext();
   const {
     availableBalance,
     isLoadingFees,
@@ -81,8 +81,7 @@ export function RpcStxSignTransaction() {
     const signedTransaction = await signStacksTx(unsignedTxForBroadcast);
 
     if (!signedTransaction) {
-      chrome.tabs.sendMessage(
-        tabId,
+      chrome.runtime.sendMessage(
         createRpcErrorResponse('stx_signTransaction', {
           id: requestId,
           error: {
@@ -94,8 +93,7 @@ export function RpcStxSignTransaction() {
       throw new Error('Error signing stacks transaction');
     }
 
-    chrome.tabs.sendMessage(
-      tabId,
+    chrome.runtime.sendMessage(
       createRpcSuccessResponse('stx_signTransaction', {
         id: requestId,
         result: {

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
@@ -86,7 +86,7 @@ export function useStxSendForm() {
 
       const tx = await generateTx(values);
       if (!tx) return logger.error('Attempted to generate unsigned tx, but tx is undefined');
-      sendFormNavigate.toConfirmAndSignStxTransaction(tx, showFeeChangeWarning);
+      void sendFormNavigate.toConfirmAndSignStxTransaction(tx, showFeeChangeWarning);
     },
   };
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
@@ -81,6 +81,25 @@ export function useStxSendForm() {
         fee: Number(values.fee),
       });
 
+      // const port = chrome.runtime.connect(chrome.runtime.id);
+      // port.postMessage({
+      //   jsonrpc: '2.0',
+      //   method: 'stx_transferStx',
+      //   params: {
+      //     recipient: values.recipient,
+      //     amount: values.amount,
+      //   },
+      // });
+
+      // chrome.runtime.sendMessage({
+      //   jsonrpc: '2.0',
+      //   method: 'stx_transferStx',
+      //   params: {
+      //     recipient: values.recipient,
+      //     amount: values.amount,
+      //   },
+      // });
+
       // if fee has changed, show info message
       const showFeeChangeWarning = initialFee !== values.fee;
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -16,6 +16,7 @@ import {
   isLegacyMessage,
 } from './messaging/legacy/legacy-external-message-handler';
 import { rpcMessageHandler } from './messaging/rpc-message-handler';
+import { rpcRequestSchema } from './messaging/rpc-request-utils';
 import { initAddressMonitor } from './monitors/address-monitor';
 
 initContextMenuActions();
@@ -69,6 +70,11 @@ chrome.runtime.onConnect.addListener(port => {
 //
 // Events from the extension frames script
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (rpcRequestSchema.safeParse(message).success) {
+    void rpcMessageHandler(message, sender);
+    return true;
+  }
+
   void internalBackgroundMessageHandler(message, sender, sendResponse);
 
   // Listener fn must return `true` to indicate the response will be async

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -21,6 +21,16 @@ import { initAddressMonitor } from './monitors/address-monitor';
 initContextMenuActions();
 warnUsersAboutDevToolsDangers();
 
+initAddressMonitor().catch(e => {
+  logger.error('Unable to Initialise Address Monitor: ', e);
+});
+
+listenForSessionDurationPort({
+  onSessionEnd(sessionMetadata) {
+    void queueAnalyticsRequest('user_session_complete', sessionMetadata);
+  },
+});
+
 chrome.runtime.onInstalled.addListener(async details => {
   if (details.reason === 'install' && process.env.WALLET_ENVIRONMENT !== 'testing') {
     await chrome.tabs.create({
@@ -34,7 +44,7 @@ chrome.runtime.onConnect.addListener(port => {
   if (port.name !== CONTENT_SCRIPT_PORT) return;
 
   port.onMessage.addListener((message: LegacyMessageFromContentScript | RpcRequests, port) => {
-    if (!port.sender?.tab?.id)
+    if (!port.sender || !port.sender?.tab?.id)
       return logger.error('Message reached background script without a corresponding tab');
 
     // Chromium/Firefox discrepancy
@@ -52,7 +62,7 @@ chrome.runtime.onConnect.addListener(port => {
     // TODO:
     // Here we'll handle all messages using the rpc style comm method
     // For now all messages are handled as legacy format
-    void rpcMessageHandler(message, port);
+    void rpcMessageHandler(message, port.sender);
   });
 });
 
@@ -60,16 +70,7 @@ chrome.runtime.onConnect.addListener(port => {
 // Events from the extension frames script
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   void internalBackgroundMessageHandler(message, sender, sendResponse);
+
   // Listener fn must return `true` to indicate the response will be async
   return true;
-});
-
-initAddressMonitor().catch(e => {
-  logger.error('Unable to Initialise Address Monitor: ', e);
-});
-
-listenForSessionDurationPort({
-  onSessionEnd(sessionMetadata) {
-    void queueAnalyticsRequest('user_session_complete', sessionMetadata);
-  },
 });

--- a/src/background/messaging/internal-methods/message-handler.ts
+++ b/src/background/messaging/internal-methods/message-handler.ts
@@ -1,6 +1,6 @@
 import { logger } from '@shared/logger';
 import { InternalMethods } from '@shared/message-types';
-import { BackgroundMessages } from '@shared/messages';
+import type { BackgroundMessages } from '@shared/messages';
 
 import { syncAddressMonitor } from '@background/monitors/address-monitor';
 
@@ -44,7 +44,7 @@ export async function internalBackgroundMessageHandler(
       break;
   }
 
-  if (message.method.includes('bitcoinKeys/signOut')) {
+  if ('method' in message && (message as any).method === 'bitcoinKeys/signOut') {
     await syncAddressMonitor([]);
   }
 

--- a/src/background/messaging/legacy/legacy-external-message-handler.ts
+++ b/src/background/messaging/legacy/legacy-external-message-handler.ts
@@ -66,10 +66,13 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.authenticationRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.authenticationRequest });
 
-      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
-        ['authRequest', payload],
-        ['flow', ExternalMethods.authenticationRequest],
-      ]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+        port.sender!,
+        [
+          ['authRequest', payload],
+          ['flow', ExternalMethods.authenticationRequest],
+        ]
+      );
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.ChooseAccount, urlParams);
       listenForPopupClose({
@@ -84,11 +87,14 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.transactionRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.transactionRequest });
 
-      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
-        ['request', payload],
-        ['flow', ExternalMethods.transactionRequest],
-        ...getNetworkParamsFromPayload(payload),
-      ]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+        port.sender!,
+        [
+          ['request', payload],
+          ['flow', ExternalMethods.transactionRequest],
+          ...getNetworkParamsFromPayload(payload),
+        ]
+      );
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.TransactionRequest, urlParams);
       listenForPopupClose({
@@ -103,12 +109,15 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.signatureRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.signatureRequest });
 
-      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
-        ['request', payload],
-        ['messageType', 'utf8'],
-        ['flow', ExternalMethods.signatureRequest],
-        ...getNetworkParamsFromPayload(payload),
-      ]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+        port.sender!,
+        [
+          ['request', payload],
+          ['messageType', 'utf8'],
+          ['flow', ExternalMethods.signatureRequest],
+          ...getNetworkParamsFromPayload(payload),
+        ]
+      );
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.SignatureRequest, urlParams);
       listenForPopupClose({
@@ -123,12 +132,15 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.structuredDataSignatureRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.structuredDataSignatureRequest });
 
-      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
-        ['request', payload],
-        ['messageType', 'structured'],
-        ['flow', ExternalMethods.structuredDataSignatureRequest],
-        ...getNetworkParamsFromPayload(payload),
-      ]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+        port.sender!,
+        [
+          ['request', payload],
+          ['messageType', 'structured'],
+          ['flow', ExternalMethods.structuredDataSignatureRequest],
+          ...getNetworkParamsFromPayload(payload),
+        ]
+      );
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.SignatureRequest, urlParams);
       listenForPopupClose({
@@ -143,9 +155,10 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.profileUpdateRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.profileUpdateRequest });
 
-      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
-        ['request', payload],
-      ]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+        port.sender!,
+        [['request', payload]]
+      );
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.ProfileUpdateRequest, urlParams);
       listenForPopupClose({
@@ -160,9 +173,10 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.psbtRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.psbtRequest });
 
-      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
-        ['request', payload],
-      ]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+        port.sender!,
+        [['request', payload]]
+      );
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.PsbtRequest, urlParams);
       listenForPopupClose({

--- a/src/background/messaging/rpc-methods/get-addresses.ts
+++ b/src/background/messaging/rpc-methods/get-addresses.ts
@@ -12,9 +12,9 @@ import {
 
 const sharedGetAddressesHandler = async (
   request: RpcRequest<typeof getAddresses> | RpcRequest<typeof stxGetAddresses>,
-  port: chrome.runtime.Port
+  sender: chrome.runtime.MessageSender
 ) => {
-  const { urlParams, tabId } = createConnectingAppMetadataSearchParams(port, [
+  const { urlParams, tabId } = createConnectingAppMetadataSearchParams(sender, [
     ['requestId', request.id],
     ['rpcRequest', encodeBase64Json(request)],
   ]);

--- a/src/background/messaging/rpc-methods/open.ts
+++ b/src/background/messaging/rpc-methods/open.ts
@@ -13,17 +13,17 @@ import { openNewTabWithWallet, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   createConnectingAppSearchParamsWithLastKnownAccount,
-  getHostnameFromPort,
+  getHostnameFromSender,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
 
-export const openHandler = defineRpcRequestHandler(open.method, async (request, port) => {
-  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+export const openHandler = defineRpcRequestHandler(open.method, async (request, sender) => {
+  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
     ['requestId', request.id],
   ]);
 
   const state = await getRootState();
-  const hostname = getHostnameFromPort(port);
+  const hostname = getHostnameFromSender(sender);
 
   if (!state) {
     sendMissingStateErrorToTab({ tabId, method: request.method, id: request.id });

--- a/src/background/messaging/rpc-methods/send-transfer.ts
+++ b/src/background/messaging/rpc-methods/send-transfer.ts
@@ -21,19 +21,17 @@ import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
   createConnectingAppSearchParamsWithLastKnownAccount,
-  getTabIdFromPort,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
 
 export const sendTransferHandler = defineRpcRequestHandler(
   sendTransfer.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     if (isUndefined(request.params)) {
       void trackRpcRequestError({ endpoint: 'sendTransfer', error: 'Undefined parameters' });
 
-      chrome.tabs.sendMessage(
-        getTabIdFromPort(port),
+      sendResponse(
         createRpcErrorResponse('sendTransfer', {
           id: request.id,
           error: { code: RpcErrorCode.INVALID_REQUEST, message: 'Parameters undefined' },
@@ -50,8 +48,7 @@ export const sendTransferHandler = defineRpcRequestHandler(
     if (!validateRpcSendTransferParams(params)) {
       void trackRpcRequestError({ endpoint: 'sendTransfer', error: 'Invalid parameters' });
 
-      chrome.tabs.sendMessage(
-        getTabIdFromPort(port),
+      sendResponse(
         createRpcErrorResponse('sendTransfer', {
           id: request.id,
           error: {
@@ -83,7 +80,7 @@ export const sendTransferHandler = defineRpcRequestHandler(
     }
 
     const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
-      port,
+      sender,
       requestParams
     );
 

--- a/src/background/messaging/rpc-methods/sign-message.ts
+++ b/src/background/messaging/rpc-methods/sign-message.ts
@@ -18,18 +18,16 @@ import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
   createConnectingAppSearchParamsWithLastKnownAccount,
-  getTabIdFromPort,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
 
 export const signMessageHandler = defineRpcRequestHandler(
   signMessage.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     if (isUndefined(request.params)) {
       void trackRpcRequestError({ endpoint: 'signMessage', error: 'Undefined parameters' });
-      chrome.tabs.sendMessage(
-        getTabIdFromPort(port),
+      sendResponse(
         createRpcErrorResponse('signMessage', {
           id: request.id,
           error: { code: RpcErrorCode.INVALID_REQUEST, message: 'Parameters undefined' },
@@ -41,8 +39,7 @@ export const signMessageHandler = defineRpcRequestHandler(
     if (!validateRpcSignMessageParams(request.params)) {
       void trackRpcRequestError({ endpoint: 'signMessage', error: 'Invalid parameters' });
 
-      chrome.tabs.sendMessage(
-        getTabIdFromPort(port),
+      sendResponse(
         createRpcErrorResponse('signMessage', {
           id: request.id,
           error: {
@@ -60,8 +57,7 @@ export const signMessageHandler = defineRpcRequestHandler(
     if (!isSupportedMessageSigningPaymentType(paymentType)) {
       void trackRpcRequestError({ endpoint: 'signMessage', error: 'Unsupported payment type' });
 
-      chrome.tabs.sendMessage(
-        getTabIdFromPort(port),
+      sendResponse(
         createRpcErrorResponse('signMessage', {
           id: request.id,
           error: {
@@ -88,7 +84,7 @@ export const signMessageHandler = defineRpcRequestHandler(
     }
 
     const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
-      port,
+      sender,
       requestParams
     );
     const { id } = await triggerRequestPopupWindowOpen(RouteUrls.RpcSignBip322Message, urlParams);

--- a/src/background/messaging/rpc-methods/stx-call-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-call-contract.ts
@@ -19,17 +19,18 @@ import {
 
 export const stxCallContractHandler = defineRpcRequestHandler(
   stxCallContract.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     const { id: requestId, method, params } = request;
     const { status } = validateRequestParams({
       id: requestId,
       method,
       params,
-      port,
+      sender,
+      sendResponse,
       schema: stxCallContract.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/stx-deploy-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-deploy-contract.ts
@@ -19,17 +19,18 @@ import {
 
 export const stxDeployContractHandler = defineRpcRequestHandler(
   stxDeployContract.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     const { id: requestId, method, params } = request;
     const { status } = validateRequestParams({
       id: requestId,
       method,
       params,
-      port,
+      sender,
+      sendResponse,
       schema: stxDeployContract.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/stx-sign-transaction.ts
+++ b/src/background/messaging/rpc-methods/stx-sign-transaction.ts
@@ -19,17 +19,18 @@ import {
 
 export const stxSignTransactionHandler = defineRpcRequestHandler(
   stxSignTransaction.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     const { id: requestId, method, params } = request;
     const { status } = validateRequestParams({
       id: requestId,
       method,
       params,
-      port,
+      sender,
+      sendResponse,
       schema: stxSignTransaction.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/stx-transfer-sip10-ft.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-sip10-ft.ts
@@ -19,17 +19,18 @@ import {
 
 export const stxTransferSip10FtHandler = defineRpcRequestHandler(
   stxTransferSip10Ft.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     const { id: requestId, method, params } = request;
     const { status } = validateRequestParams({
       id: requestId,
       method,
       params,
-      port,
+      sender,
+      sendResponse,
       schema: stxTransferSip10Ft.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/stx-transfer-sip9-nft.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-sip9-nft.ts
@@ -19,17 +19,18 @@ import {
 
 export const stxTransferSip9NftHandler = defineRpcRequestHandler(
   stxTransferSip9Nft.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     const { id: requestId, method, params } = request;
     const { status } = validateRequestParams({
       id: requestId,
       method,
       params,
-      port,
+      sender,
+      sendResponse,
       schema: stxTransferSip9Nft.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/stx-transfer-stx.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-stx.ts
@@ -19,17 +19,18 @@ import {
 
 export const stxTransferStxHandler = defineRpcRequestHandler(
   stxTransferStx.method,
-  async (request, port) => {
+  async (request, sender, sendResponse) => {
     const { id: requestId, method, params } = request;
     const { status } = validateRequestParams({
       id: requestId,
       method,
       params,
-      port,
+      sender,
+      sendResponse,
       schema: stxTransferStx.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(sender, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/supported-methods.ts
+++ b/src/background/messaging/rpc-methods/supported-methods.ts
@@ -1,14 +1,11 @@
 import { createRpcSuccessResponse, supportedMethods } from '@leather.io/rpc';
 
 import { defineRpcRequestHandler } from '../rpc-message-handler';
-import { createConnectingAppSearchParamsWithLastKnownAccount } from '../rpc-request-utils';
 
 export const supportedMethodsHandler = defineRpcRequestHandler(
   supportedMethods.method,
-  async (request, port) => {
-    const { tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port);
-    chrome.tabs.sendMessage(
-      tabId,
+  async (request, _sender, sendMessage) => {
+    sendMessage(
       createRpcSuccessResponse(supportedMethods.method, {
         id: request.id,
         result: {

--- a/src/background/messaging/rpc-request-utils.ts
+++ b/src/background/messaging/rpc-request-utils.ts
@@ -25,19 +25,34 @@ import { popup } from '@background/popup';
 
 import { trackRpcRequestError } from './rpc-helpers';
 
-export function getTabIdFromPort(port: chrome.runtime.Port) {
-  return port.sender?.tab?.id ?? 0;
+function getTabIdFromSender(sender: chrome.runtime.MessageSender) {
+  return sender?.tab?.id ?? 0;
 }
 
-function getOriginFromPort(port: chrome.runtime.Port) {
-  if (port.sender?.url) return new URL(port.sender.url).origin;
-  return port.sender?.origin;
+function getOriginFromSender(sender: chrome.runtime.MessageSender) {
+  if (sender?.url) return new URL(sender.url).origin;
+  return sender?.origin;
 }
 
-export function getHostnameFromPort(port: chrome.runtime.Port) {
-  const origin = getOriginFromPort(port);
-  if (!origin) throw new Error('No URL found in port sender');
+export function getHostnameFromSender(sender: chrome.runtime.MessageSender) {
+  const origin = getOriginFromSender(sender);
+  if (!origin) throw new Error('No URL found in sender');
   return getHostnameFromUrl(origin);
+}
+
+export function sendRpcResponse(
+  sender: chrome.runtime.MessageSender,
+  response: any,
+  sendResponse?: (response: any) => void
+) {
+  if (sendResponse) {
+    // Internal extension call - use sendResponse callback
+    sendResponse(response);
+  } else {
+    // External call - use chrome.tabs.sendMessage
+    const tabId = getTabIdFromSender(sender);
+    chrome.tabs.sendMessage(tabId, response);
+  }
 }
 
 //
@@ -102,12 +117,12 @@ export function listenForOriginTabClose({ tabId }: ListenForOriginTabCloseArgs) 
 export type RequestParams = [string, string][];
 
 export function createConnectingAppMetadataSearchParams(
-  port: chrome.runtime.Port,
+  sender: chrome.runtime.MessageSender,
   otherParams: RequestParams = []
 ) {
   const urlParams = new URLSearchParams();
-  const origin = getOriginFromPort(port);
-  const tabId = getTabIdFromPort(port);
+  const origin = getOriginFromSender(sender);
+  const tabId = getTabIdFromSender(sender);
   urlParams.set('origin', origin ?? '');
   urlParams.set('tabId', tabId.toString());
   otherParams.forEach(([key, value]) => urlParams.append(key, value));
@@ -115,12 +130,12 @@ export function createConnectingAppMetadataSearchParams(
 }
 
 export async function createConnectingAppSearchParamsWithLastKnownAccount(
-  port: chrome.runtime.Port,
+  sender: chrome.runtime.MessageSender,
   otherParams: RequestParams = []
 ) {
-  const { urlParams, origin, tabId } = createConnectingAppMetadataSearchParams(port, otherParams);
+  const { urlParams, origin, tabId } = createConnectingAppMetadataSearchParams(sender, otherParams);
   if (origin) {
-    const appPermissions = await getPermissionsByOrigin(getHostnameFromPort(port));
+    const appPermissions = await getPermissionsByOrigin(getHostnameFromSender(sender));
     if (appPermissions) {
       urlParams.set('accountIndex', appPermissions.accountIndex.toString());
     }
@@ -146,20 +161,21 @@ interface ValidateRequestParamsArgs {
   id: string;
   method: RpcMethodNames;
   params: unknown;
-  port: chrome.runtime.Port;
+  sender: chrome.runtime.MessageSender;
+  sendResponse(response: any): void;
   schema: z.Schema;
 }
 export function validateRequestParams({
   id,
   method,
   params,
-  port,
+  // sender,
+  sendResponse,
   schema,
 }: ValidateRequestParamsArgs): { status: ValidationResult } {
   if (isUndefined(params)) {
     void trackRpcRequestError({ endpoint: method, error: RpcErrorMessage.UndefinedParams });
-    chrome.tabs.sendMessage(
-      getTabIdFromPort(port),
+    sendResponse(
       createRpcErrorResponse(method, {
         id,
         error: { code: RpcErrorCode.INVALID_REQUEST, message: RpcErrorMessage.UndefinedParams },
@@ -171,8 +187,7 @@ export function validateRequestParams({
   if (!validateRpcParams(params, schema)) {
     void trackRpcRequestError({ endpoint: method, error: RpcErrorMessage.InvalidParams });
 
-    chrome.tabs.sendMessage(
-      getTabIdFromPort(port),
+    sendResponse(
       createRpcErrorResponse(method, {
         id,
         error: {


### PR DESCRIPTION
> Try out Leather build c77bc37 — [Extension build](https://github.com/leather-io/extension/actions/runs/17443172499), [Test report](https://leather-io.github.io/playwright-reports/refactor/decouple-port), [Storybook](https://refactor/decouple-port--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/decouple-port)<!-- Sticky Header Marker -->

This PR proposes that we utilise our RPC API internally. Rather than building some flows internally (send form signing step, sending inscriptions etc) we run actions exclusively via our API.

**Demo**

https://github.com/user-attachments/assets/85935628-6082-4089-9315-dd7b2b032a4f


https://github.com/user-attachments/assets/390ea304-32d7-4612-9878-ae96085c889e




https://trustmachines.slack.com/archives/C05LRS7G44R/p1757059108955959

**Motivation**
Leather currently has a several ways of doing the same thing. Consider signing a tx. This is currently done in three places: legacy JWT flows, RPC API, and actually in the extension (send form). This is very costly to maintain and just not a particularly efficient way of building a wallet. We need to move quickly, and this slows us down.

Using the RPC API exclusively has several benefits. First, we'll be more efficient as we build one flow flawlessly and reuse it everywhere. Second, as we build our features for ourselves, we can also expose them as an API. Consider inscription sends. This can be done in the wallet, but there's no API for it. If we'd built this as an API from the start, we could've exposed this as an API for apps to use as well, slowly growing a more compelling suite of tools for builders.

Some changes to the message passing are made here. This is the existing behaviour: we pass the RPC events around, then the popup returns it directly to the tab.

**Existing flow**

<img width="958" height="444" alt="image" src="https://github.com/user-attachments/assets/23c6cde8-221a-4295-bb53-906903101960" />


<details>

<summary>Mermaid</summary>

```mermaid
sequenceDiagram
    participant App
    participant ContentScript
    participant Background
    participant Popup

    App->>ContentScript: new CustomEvent()
    ContentScript->>Background: chrome.runtime.Port
    Background->>Popup: chrome.window.open()
    Popup->>ContentScript: chome.tab.sendMessage()
    ContentScript->>App: window.postMessage()
```

</details>


Here, this changes such that the RPC result is returned via the background script.

**Proposed flow**

<img width="975" height="455" alt="image" src="https://github.com/user-attachments/assets/df369e7e-e327-4845-a819-d952c5e3528f" />


<details>

<summary>Mermaid</summary>

```mermaid
sequenceDiagram
    participant App
    participant ContentScript
    participant Background
    participant Popup

    App->>ContentScript: new CustomEvent()
    ContentScript->>Background: chrome.runtime.Port
    Background->>Popup: chrome.window.open()
    Popup->>Background: chome.runtime.sendMessage()
    Background->>ContentScript: chome.tab.sendMessage()
    ContentScript->>App: window.postMessage()
```


</details>


The reason for this change is that, if the extension can also trigger the RPC APIs, then it isn't necessarily a tab we need to send the result to. It could be the action popup that has no `tabId`. I've baked in [some conditional logic](https://github.com/leather-io/extension/pull/6356/files#diff-dc5f5cf4395da344b14d94709d2d8b7d5b5132e7685463eed05551817d3b2693R49-R55) that changes the transport depending if the origin is the extension. I'm not 100% on this change, as it does add an additional dependency on the background script, that has revealed some race condition behaviours (e.g. the closed window listener returns an error event as it's detected before the success result). Either these need to be fixed, or the conditional logic should happen in the popup.