### PR TITLE
feat(ledger): add windows firmware warning

### DIFF
--- a/src/app/common/hooks/use-platform-info.ts
+++ b/src/app/common/hooks/use-platform-info.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export function usePlatformInfo() {
+  const [platformInfo, setPlatformInfo] = useState<chrome.runtime.PlatformInfo | null>(null);
+
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    async function fetchPlatformInfo() {
+      try {
+        setError(null);
+        const info = await chrome.runtime.getPlatformInfo();
+        setPlatformInfo(info);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to get platform info'));
+      }
+    }
+
+    void fetchPlatformInfo();
+  }, []);
+
+  return { platformInfo, isWindows: platformInfo?.os === 'win', error };
+}

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger.tsx
@@ -3,8 +3,9 @@ import { Suspense, lazy, useMemo } from 'react';
 import { Box, HStack, Stack, styled } from 'leather-styles/jsx';
 
 import type { SupportedBlockchains } from '@leather.io/models';
-import { BitcoinIcon, Button, Link, StacksIcon } from '@leather.io/ui';
+import { BitcoinIcon, Button, Callout, Link, StacksIcon } from '@leather.io/ui';
 
+import { usePlatformInfo } from '@app/common/hooks/use-platform-info';
 import { Divider } from '@app/components/layout/divider';
 
 import { LedgerWrapper } from '../../components/ledger-wrapper';
@@ -34,6 +35,8 @@ export function ConnectLedger(props: ConnectLedgerProps) {
     chain,
   } = props;
 
+  const { isWindows } = usePlatformInfo();
+
   const showBitcoinConnectButton = useMemo(() => {
     return chain === 'bitcoin' || !!connectBitcoin;
   }, [chain, connectBitcoin]);
@@ -62,8 +65,6 @@ export function ConnectLedger(props: ConnectLedgerProps) {
       </Box>
 
       <Stack gap="space.04" justifyItems="flex-start" textAlign="start" pb="space.06">
-        <styled.span textStyle="heading.05">Please follow the instructions:</styled.span>
-
         <Stack gap="space.01" mb="space.02">
           {instructions.map((instruction, index) => (
             <styled.span textStyle="body.01" key={index}>
@@ -103,6 +104,22 @@ export function ConnectLedger(props: ConnectLedgerProps) {
           {warning}
         </Box>
       )}
+
+      {isWindows && (
+        <Callout variant="warning" mb="space.06" mx="space.06" textAlign="left">
+          Ledger devices running newer firmware versions may not work correctly.{' '}
+          <styled.a
+            fontSize="inherit"
+            border={0}
+            textDecoration="underline"
+            href="https://support.ledger.com/article/Windows-Cannot-connect-via-WebUSB"
+            target="_blank"
+          >
+            Learn more about the issue on Ledger's support page
+          </styled.a>
+        </Callout>
+      )}
+
       {showInstructions ? (
         <Stack gap="space.05" width="100%">
           <Divider />


### PR DESCRIPTION
> Try out Leather build 3aa9ac0 — [Extension build](https://github.com/leather-io/extension/actions/runs/17561631844), [Test report](https://leather-io.github.io/playwright-reports/feat/inline-ledger-warning-windows), [Storybook](https://feat/inline-ledger-warning-windows--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/inline-ledger-warning-windows)<!-- Sticky Header Marker -->

This PR adds a warning for windows users only with information about the Ledger incompatibility with the latest firmware. 

It links to this page that names Leather specifically https://support.ledger.com/article/Windows-Cannot-connect-via-WebUSB


<img width="1912" height="1237" alt="image" src="https://github.com/user-attachments/assets/a85ef087-650e-4fbb-a808-c563152cd188" />

<img width="1912" height="1237" alt="image" src="https://github.com/user-attachments/assets/a76672f2-5696-475b-96cf-3c128dca5410" />
